### PR TITLE
Fix flaky Ubuntu CI: serialize libsafety.so build in safety tests

### DIFF
--- a/opendbc/safety/tests/libsafety/libsafety_py.py
+++ b/opendbc/safety/tests/libsafety/libsafety_py.py
@@ -12,9 +12,16 @@ libsafety_dir = os.path.dirname(os.path.abspath(__file__))
 
 def _build_libsafety() -> str:
   """Compile libsafety.so to a temp file and return its path."""
+  # unittest-parallel can import this module concurrently from multiple
+  # worker processes. Building through a shared intermediate object path
+  # (`safety.os`) must be serialized to avoid clobbering partially written
+  # objects and producing invalid shared libraries.
+  import fcntl
+
   root = str(Path(libsafety_dir).parents[3])
   safety_c = os.path.join(libsafety_dir, "safety.c")
   safety_os = os.path.join(libsafety_dir, "safety.os")
+  lock_path = os.path.join(libsafety_dir, ".libsafety-build.lock")
 
   cflags = [
     '-Wall', '-Wextra', '-Werror', '-nostdlib', '-fno-builtin',
@@ -30,8 +37,10 @@ def _build_libsafety() -> str:
   fd, libsafety_so = tempfile.mkstemp(suffix='.so')
   os.close(fd)
 
-  subprocess.check_call(['cc', '-fPIC', *cflags, '-I', root, '-c', safety_c, '-o', safety_os])
-  subprocess.check_call(['cc', '-shared', safety_os, '-o', libsafety_so, *ldflags])
+  with open(lock_path, "w") as lock_file:
+    fcntl.flock(lock_file, fcntl.LOCK_EX)
+    subprocess.check_call(['cc', '-fPIC', *cflags, '-I', root, '-c', safety_c, '-o', safety_os])
+    subprocess.check_call(['cc', '-shared', safety_os, '-o', libsafety_so, *ldflags])
   return libsafety_so
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Validation
* Dongle ID: N/A (CI-only change)
* Route: N/A

## Summary
- add an inter-process file lock in `opendbc/safety/tests/libsafety/libsafety_py.py` around the compile+link steps in `_build_libsafety()`
- keep the existing build output locations/flags unchanged while preventing concurrent workers from clobbering the shared `safety.os` intermediate
- document why this lock is needed when `unittest-parallel` imports libsafety in multiple worker processes

## Why this fixes the linked failure
The failing Ubuntu job reports repeated:
`undefined symbol: set_safety_hooks` while loading `/tmp/tmp*.so` from `libsafety_py`. That symbol is defined in `opendbc/safety/safety.h`, so this pattern is consistent with occasional malformed/incomplete shared objects produced by concurrent build races. Serializing build of the shared intermediate object eliminates that race path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab059b9d-6b2c-417d-9596-979e1489ec23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab059b9d-6b2c-417d-9596-979e1489ec23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

