### PR TITLE
Extend car diff wait window for fork PRs

### DIFF
--- a/.github/workflows/car_diff.yml
+++ b/.github/workflows/car_diff.yml
@@ -8,7 +8,7 @@ jobs:
   comment:
     name: comment
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 25
     permissions:
       contents: read
       pull-requests: write
@@ -16,6 +16,20 @@ jobs:
     steps:
     - name: Wait for car diff
       id: wait
+      if: github.event.pull_request.head.repo.fork != true
+      timeout-minutes: 10
+      continue-on-error: true
+      uses: lewagon/wait-on-check-action@v1.3.4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        check-name: car diff
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        allowed-conclusions: success
+        wait-interval: 20
+    - name: Wait for car diff
+      id: wait_fork
+      if: github.event.pull_request.head.repo.fork == true
+      timeout-minutes: 20
       continue-on-error: true
       uses: lewagon/wait-on-check-action@v1.3.4
       with:
@@ -25,7 +39,7 @@ jobs:
         allowed-conclusions: success
         wait-interval: 20
     - name: Download car diff
-      if: steps.wait.outcome == 'success'
+      if: steps.wait.outcome == 'success' || steps.wait_fork.outcome == 'success'
       uses: dawidd6/action-download-artifact@v6
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -36,7 +50,7 @@ jobs:
         path: .
         allow_forks: true
     - name: Comment car diff on PR
-      if: steps.wait.outcome == 'success'
+      if: steps.wait.outcome == 'success' || steps.wait_fork.outcome == 'success'
       uses: thollander/actions-comment-pull-request@v2
       with:
         filePath: diff.txt


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Validation
* Dongle ID: N/A
* Route: N/A

## Summary
- keep the existing 10 minute wait path for same-repo PRs
- add a fork-only wait step with a 20 minute step timeout
- raise the job timeout so the longer fork wait can complete

## Testing
- validated `.github/workflows/car_diff.yml` parses successfully with `python3` + `yaml.safe_load`
- reviewed the workflow diff to confirm only fork PR behavior is extended
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-298afd7a-0233-4d17-b9f2-ecbd6bab45de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-298afd7a-0233-4d17-b9f2-ecbd6bab45de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

