### PR TITLE
tests: skip wrapper can.h in MISRA mutation sampling

### DIFF
--- a/opendbc/safety/tests/misra/test_mutation.py
+++ b/opendbc/safety/tests/misra/test_mutation.py
@@ -12,6 +12,7 @@ ROOT = os.path.join(HERE, "../../../../")
 
 IGNORED_PATHS = (
   'opendbc/safety/main.c',
+  'opendbc/safety/can.h',
   'opendbc/safety/tests/',
   'opendbc/safety/board/',
 )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- exclude `opendbc/safety/can.h` from MISRA mutation test candidate files
- keep mutation sampling focused on files that are part of the cppcheck translation unit

## Why
`opendbc/safety/can.h` is a wrapper include that now only re-exports `board/can.h`. Mutating this wrapper can be ignored by cppcheck in the mutation harness, causing flaky false negatives like:
- `test_misra_mutation[opendbc/safety/can.h-misra-c2012-13.3-<lambda>-True]`

Excluding the wrapper makes the mutation test deterministic across runners.

## Testing
- Verified file selection logic excludes `opendbc/safety/can.h` and still has >20 candidates.
- CI expected to exercise `./test.sh` MISRA mutation path on this branch.

Validation
* Dongle ID:
* Route:

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5363a79f-c736-4aa8-8f64-32f5c79dc410"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5363a79f-c736-4aa8-8f64-32f5c79dc410"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

