### PR TITLE
Reset Honda ABS previous-sample state on safety init

### DIFF
--- a/opendbc/car/honda/carstate.py
+++ b/opendbc/car/honda/carstate.py
@@ -88,10 +88,15 @@ class CarState(CarStateBase):
     v_wheel = sum([cp.vl["WHEEL_SPEEDS"][f"WHEEL_SPEED_{s}"] for s in ("FL", "FR", "RL", "RR")]) / 4.0 * CV.KPH_TO_MS
     if self.CP.carFingerprint == CAR.ACURA_INTEGRA:  # use ABS_SENSOR for Integra since no ENGINE_DATA message
       abs_counter = cp.vl["ABS_SENSOR"]["COUNTER"]
-      if self.abs_counter_prev != abs_counter:
-        self.lowspeed_source = sum((cp.vl["ABS_SENSOR"][f"ABS_SENSOR_{s}"] - getattr(self, f"abs_prior_{s}")) % 256 for s in ("FL", "FR", "RL", "RR"))
-        for s in ("FL", "FR", "RL", "RR"):
-          setattr(self, f"abs_prior_{s}", cp.vl["ABS_SENSOR"][f"ABS_SENSOR_{s}"])
+      abs_values = {s: cp.vl["ABS_SENSOR"][f"ABS_SENSOR_{s}"] for s in ("FL", "FR", "RL", "RR")}
+      has_new_abs_sample = (self.abs_counter_prev != abs_counter) or any(abs_values[s] != getattr(self, f"abs_prior_{s}") for s in abs_values)
+
+      # Keep last low-speed value when no new ABS frame arrives, but still process
+      # samples where values changed even if the 2-bit counter wrapped/replayed.
+      if has_new_abs_sample:
+        self.lowspeed_source = sum((abs_values[s] - getattr(self, f"abs_prior_{s}")) % 256 for s in abs_values)
+        for s in abs_values:
+          setattr(self, f"abs_prior_{s}", abs_values[s])
         self.abs_counter_prev = abs_counter
     else:
       self.lowspeed_source = cp.vl["ENGINE_DATA"]["XMISSION_SPEED"]

--- a/opendbc/safety/modes/honda.h
+++ b/opendbc/safety/modes/honda.h
@@ -43,6 +43,10 @@ static bool honda_bosch_long = false;
 static bool honda_bosch_radarless = false;
 static bool honda_bosch_canfd = false;
 static bool honda_no_engine_data_msg = false;
+static unsigned int honda_abs_prev_fl = 0U;
+static unsigned int honda_abs_prev_fr = 0U;
+static unsigned int honda_abs_prev_rl = 0U;
+static unsigned int honda_abs_prev_rr = 0U;
 typedef enum {HONDA_NIDEC, HONDA_BOSCH} HondaHw;
 static HondaHw honda_hw = HONDA_NIDEC;
 
@@ -84,15 +88,11 @@ static void honda_rx_hook(const CANPacket_t *msg) {
 
   // sample speed - 0x158 used for all supported Hondas except Integra (use 0x20E abs_sensor message)
   if (honda_no_engine_data_msg && (msg->addr == 0x20EU)) {
-    static unsigned int abs_prev_fl = 0;
-    static unsigned int abs_prev_fr = 0;
-    static unsigned int abs_prev_rl = 0;
-    static unsigned int abs_prev_rr = 0;
-    vehicle_moving = ((msg->data[0] != abs_prev_fl) || (msg->data[1] != abs_prev_fr) || (msg->data[2] != abs_prev_rl) || (msg->data[3] != abs_prev_rr));
-    abs_prev_fl = msg->data[0];
-    abs_prev_fr = msg->data[1];
-    abs_prev_rl = msg->data[2];
-    abs_prev_rr = msg->data[3];
+    vehicle_moving = ((msg->data[0] != honda_abs_prev_fl) || (msg->data[1] != honda_abs_prev_fr) || (msg->data[2] != honda_abs_prev_rl) || (msg->data[3] != honda_abs_prev_rr));
+    honda_abs_prev_fl = msg->data[0];
+    honda_abs_prev_fr = msg->data[1];
+    honda_abs_prev_rl = msg->data[2];
+    honda_abs_prev_rr = msg->data[3];
   } else if (msg->addr == 0x158U) {
     vehicle_moving = msg->data[0] | msg->data[1];
   } else {
@@ -393,6 +393,10 @@ static safety_config honda_bosch_init(uint16_t param) {
   honda_bosch_radarless = GET_FLAG(param, HONDA_PARAM_RADARLESS);
   honda_bosch_canfd = GET_FLAG(param, HONDA_PARAM_BOSCH_CANFD);
   honda_no_engine_data_msg = GET_FLAG(param, HONDA_PARAM_NO_ENGINE_DATA_MSG);
+  honda_abs_prev_fl = 0U;
+  honda_abs_prev_fr = 0U;
+  honda_abs_prev_rl = 0U;
+  honda_abs_prev_rr = 0U;
   // Checking for alternate brake override from safety parameter
   honda_alt_brake_msg = GET_FLAG(param, HONDA_PARAM_ALT_BRAKE);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Validation
* Dongle ID: N/A (safety/carstate-only change)
* Route: N/A (test-model parity fix)

## Summary
- Move Honda ABS previous-sample values used by `honda_rx_hook` to module-level state and reset them during `honda_bosch_init`.
- Add Integra carstate handling to treat an ABS sample as new when either the counter changes or wheel-byte values change.
- Keep the change scoped to Integra ABS low-speed behavior to address rare standstill parity mismatches in `test_models`.

## Why
`test_models` still showed a rare Integra-only mismatch (`{'standstill': 2}`) after safety-side state reset. In the failing route, a small number of frames appear to have wheel-byte changes that don't align with a pure counter-only update gate. Updating carstate on either signal keeps standstill parity with safety's frame-delta logic.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0716267-06ec-40bb-a6ef-119fa6277fce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0716267-06ec-40bb-a6ef-119fa6277fce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

