### PR TITLE
test_mutation: ignore .csm_* cppcheck temp files in copytree

### DIFF
--- a/opendbc/safety/tests/misra/test_mutation.py
+++ b/opendbc/safety/tests/misra/test_mutation.py
@@ -47,7 +47,7 @@ mutations = random.sample(mutations, 2)  # can remove this once cppcheck is fast
 def test_misra_mutation(fn, rule, transform, should_fail):
   with tempfile.TemporaryDirectory() as tmp:
     shutil.copytree(ROOT, tmp, dirs_exist_ok=True,
-                    ignore=shutil.ignore_patterns('.venv', '.git', '*.ctu-info', '.hypothesis'))
+                    ignore=shutil.ignore_patterns('.venv', '.git', '*.ctu-info', '.hypothesis', '.csm_*'))
 
     # apply patch
     if fn is not None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Minimal fix for the flaky `test_misra_mutation` failures seen on `0110-op-honda` CI, e.g. [run 26407850245 job 77735372096](https://github.com/mvl-boston/opendbc/actions/runs/26407850245/job/77735372096):

```
FAILED opendbc/safety/tests/misra/test_mutation.py::test_misra_mutation[...-misra-c2012-14.4-...]
FAILED opendbc/safety/tests/misra/test_mutation.py::test_misra_mutation[...-misra-c2012-20.5-...]
shutil.Error: [(..../opendbc/safety/tests/misra/.csm_deb_output_*.log,
                /tmp/.../opendbc/safety/tests/misra/.csm_deb_output_*.log,
                "[Errno 13] Permission denied: ...")]
```

## Cause

`pytest -n8` (pytest-xdist) runs the parametrized variants of `test_misra_mutation` in parallel. Each variant does:

```python
shutil.copytree(ROOT, tmp, ignore=shutil.ignore_patterns('.venv', '.git', '*.ctu-info', '.hypothesis'))
```

then invokes `opendbc/safety/tests/misra/test_misra.sh`, which runs the vendored cppcheck. That cppcheck creates short-lived `.csm_setup_*` and `.csm_deb_output_*.log` scratch files inside the live source tree (`opendbc/safety/tests/misra/`). When two workers overlap, one worker's `copytree` walks the source dir while the other worker's cppcheck is creating/removing those temp files, and `copy2` fails with `[Errno 13] Permission denied`.

## Fix

Add `.csm_*` to `ignore_patterns` so `copytree` skips the cppcheck scratch files, same pattern used for `.hypothesis`, `*.ctu-info`, etc.

```python
ignore=shutil.ignore_patterns('.venv', '.git', '*.ctu-info', '.hypothesis', '.csm_*')
```

## Notes / alternatives

This is a band-aid. The underlying race (parametrized misra mutation tests sharing the source tree under xdist) is removed upstream by [commaai/opendbc#3191](https://github.com/commaai/opendbc/pull/3191) "Replace pytest with unittest + unittest-parallel" (commit `2d52887be`), which collapses the variants into a single `unittest.TestCase` method using `subTest` so they no longer get scheduled across workers. Cherry-picking that is the more durable fix if you ever want to update this branch beyond the immediate failure.

Validation
* Dongle ID:
* Route:

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1657ff9d-1506-4dbb-8a03-2006a0cb28ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1657ff9d-1506-4dbb-8a03-2006a0cb28ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

