### PR TITLE
lefthook: run test commands sequentially to avoid mull apt race

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -10,7 +10,7 @@ output:
   - skips          # Print "skip" (i.e. no files matched)
 
 test:
-  parallel: true
+  parallel: false
   commands:
     # *** static analysis
     ruff:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #561. After the `.csm_*` `copytree` fix landed, CI started failing on a different race in [run 26408363009 job 77737013002](https://github.com/mvl-boston/opendbc/actions/runs/26408363009/job/77737013002):

```
E   AssertionError: MISRA test failed but not for the correct violation
E   assert 'misra-c2012-13.3' in "Executing the setup script for the 'mull-project/mull-stable' repository ...
                                  NOPE: Updating apt repository metadata cache ...
                                  Failed to update via apt-get update
                                  E: Could not get lock /var/lib/apt/lists/lock. It is held by process 4757 (apt-get)
                                  E: Unable to lock directory /var/lib/apt/lists/
                                  !!!! Oh no, your setup failed! ..."
```

## Cause

The fork's `.github/workflows/tests.yml` runs `lefthook run test` directly inside the openpilot host env created by `op.sh setup`, without first sourcing `opendbc/setup.sh` (this avoids re-doing `uv sync` into a second venv). As a side effect, `mull-runner-18` is *not* preinstalled when lefthook starts.

`lefthook.yml` runs `misra` (which is `opendbc/safety/tests/misra/test_misra.sh`) and `pytest -n8` (whose `test_mutation.py` variants also invoke `test_misra.sh` from xdist workers) in parallel. The first thing `test_misra.sh` does is:

```bash
source ../../../../setup.sh
```

and `setup.sh` does:

```bash
if ! command -v "mull-runner-18" > /dev/null 2>&1; then
  curl -1sLf 'https://dl.cloudsmith.io/public/mull-project/mull-stable/setup.deb.sh' | sudo -E bash
  sudo apt-get update && sudo apt-get install -y clang-18 mull-18
fi
```

So both the `misra` step and several pytest workers all enter the `if` body simultaneously, all call `sudo apt-get update && apt-get install`, and they race on `/var/lib/apt/lists/lock`. The loser exits non‑zero with the cloudsmith installer's "Oh no, your setup failed!" stdout, which `test_mutation.py` then evaluates against `assert rule in r.stdout` and (correctly) fails.

Upstream `commaai/opendbc` doesn't hit this because its CI runs `./test.sh`, which calls `source ./setup.sh` once serially before `lefthook run test`, pre-installing mull. The fork's workflow bypasses that.

## Fix

`parallel: false` in `lefthook.yml`. With sequential execution:

1. `misra` runs first (alphabetical order). Its `source setup.sh` installs `mull-runner-18` once, serially.
2. Then `pytest -n8` runs. Each xdist worker that sources `setup.sh` (via `test_misra.sh`) sees `command -v mull-runner-18` succeed and skips the apt install. No lock contention.

The `.csm_*` copytree race fixed in #561 is still possible between concurrent pytest xdist workers inside the `pytest` step, but that one is already handled by the `ignore_patterns` change there.

## Trade-off

Lint/test commands (`ruff`, `ty`, `codespell`, `cpplint`, `misra`, `pytest`) now run one at a time instead of in parallel, so the overall lefthook step is slower (≈ wall time goes from `max(commands)` to `sum(commands)`). Given this is purely a CI test gate and we're not in a rush, that's acceptable; it stays as close to upstream behavior as possible without touching the workflow or test code.

Validation
* Dongle ID:
* Route:

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1657ff9d-1506-4dbb-8a03-2006a0cb28ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1657ff9d-1506-4dbb-8a03-2006a0cb28ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

