### PR TITLE
Fix radar_ref_counter AttributeError in Honda CarController

### DIFF
--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -225,7 +225,7 @@ class CarController(CarControllerBase):
           self.radar_mux += 1
         can_sends.extend(hondacan.create_canfd_50hz_radar_messages(self.packer, self.CAN.pt, self.radar_mux))
       if self.frame % 20 == 0:
-        can_sends.extend(hondacan.create_canfd_5hz_radar_messages(self.packer, self.CAN.pt, self.radar_ref_counter))
+        can_sends.extend(hondacan.create_canfd_5hz_radar_messages(self.packer, self.CAN.pt, CS.radar_ref_counter))
 
     # Send steering command.
     can_sends.append(hondacan.create_steering_control(self.packer, self.CAN, apply_torque, CC.latActive, self.tja_control))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `tests` CI job was failing with 21 errors in `test_car_interfaces` for Honda Bosch CANFD cars (e.g. `HONDA_PILOT_4G`, `HONDA_PASSPORT_4G`):

```
File "opendbc/car/honda/carcontroller.py", line 228, in update
  can_sends.extend(hondacan.create_canfd_5hz_radar_messages(self.packer, self.CAN.pt, self.radar_ref_counter))
AttributeError: 'CarController' object has no attribute 'radar_ref_counter'
```

## Cause

`radar_ref_counter` is a `CarState` attribute (`CS.radar_ref_counter`), initialized to `0` and populated from `RADAR_REFERENCE.COUNTER` in `carstate.py`. The `CarController` never defines a `radar_ref_counter` attribute, so referencing `self.radar_ref_counter` inside `CarController.update` raised an `AttributeError`.

## Fix

Reference the counter from the `CarState` argument (`CS.radar_ref_counter`) instead of `self`.

```python
can_sends.extend(hondacan.create_canfd_5hz_radar_messages(self.packer, self.CAN.pt, CS.radar_ref_counter))
```

Since `CarState.update` (which sets `radar_ref_counter`) always runs before `CarController.update` in both the interface flow and the test loop, `CS.radar_ref_counter` is always defined at this point.

## Verification

- `ruff check` passes on the modified file.
- Full test run requires the openpilot host env (not available standalone), but the change directly resolves the `AttributeError` and uses the correct source of the counter value.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b00e49e-3e9d-42e3-9dc3-96972f8440a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b00e49e-3e9d-42e3-9dc3-96972f8440a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

