### PR TITLE
Guard Honda CAN-FD supp-tick lookup against missing radar frame

### DIFF
--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -214,7 +214,7 @@ class CarController(CarControllerBase):
     if (self.CP.carFingerprint in HONDA_BOSCH_CANFD) and self.CP.openpilotLongitudinalControl:
       if self.frame % 10 == 0:
         can_sends.append(hondacan.create_radar_hud_canfd(self.packer, self.CAN.pt, CC.enabled))
-      if self.supp_tick:
+      if CS.supp_tick:
         can_sends.append(hondacan.create_canfd_supplemental(self.packer, self.CAN.pt))
       if self.frame % 2 == 0:
         if self.radar_mux == 10:

--- a/opendbc/car/honda/carstate.py
+++ b/opendbc/car/honda/carstate.py
@@ -257,7 +257,7 @@ class CarState(CarStateBase):
       self.lkas_hud = cp_cam.vl["LKAS_HUD"]
     if self.CP.carFingerprint in HONDA_BOSCH_CANFD:
       self.radar_ref_counter = cp.vl["RADAR_REFERENCE"]["COUNTER"]
-      self.supp_tick = bool(len(cp_radar.vl_all["RADAR_SUPP_TICK_REFERENCE"]) > 0)
+      self.supp_tick = bool(cp_radar.vl_all.get("RADAR_SUPP_TICK_REFERENCE", {}))
 
     if self.CP.enableBsm:
       # BSM messages are on B-CAN, requires a panda forwarding B-CAN messages to CAN 0

--- a/opendbc/car/honda/carstate.py
+++ b/opendbc/car/honda/carstate.py
@@ -55,6 +55,8 @@ class CarState(CarStateBase):
 
     self.initial_accFault_cleared = False
     self.initial_accFault_cleared_timer = int(10 / DT_CTRL) # 10 seconds after startup for initial faults to clear
+    self.radar_ref_counter = 0
+    self.supp_tick = False
 
   def update(self, can_parsers) -> structs.CarState:
     cp = can_parsers[Bus.pt]
@@ -248,7 +250,6 @@ class CarState(CarStateBase):
 
     self.acc_hud = False
     self.lkas_hud = False
-    self.radar_ref_counter = 0
     if self.CP.carFingerprint not in HONDA_BOSCH:
       ret.stockFcw = cp_cam.vl["BRAKE_COMMAND"]["FCW"] != 0
       self.acc_hud = cp_cam.vl["ACC_HUD"]
@@ -257,7 +258,11 @@ class CarState(CarStateBase):
       self.lkas_hud = cp_cam.vl["LKAS_HUD"]
     if self.CP.carFingerprint in HONDA_BOSCH_CANFD:
       self.radar_ref_counter = cp.vl["RADAR_REFERENCE"]["COUNTER"]
-      self.supp_tick = bool(cp_radar.vl_all.get("RADAR_SUPP_TICK_REFERENCE", {}))
+      # Pulse true only on update cycles where a new 0x710 frame was received.
+      supp_tick_vals = cp_radar.vl_all.get("RADAR_SUPP_TICK_REFERENCE", {}).get("IGNORE", [])
+      self.supp_tick = len(supp_tick_vals) > 0
+    else:
+      self.supp_tick = False
 
     if self.CP.enableBsm:
       # BSM messages are on B-CAN, requires a panda forwarding B-CAN messages to CAN 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Validation
* Dongle ID: 3792d010590cb83a
* Route: 3792d010590cb83a/000000ed--f3ce73351d

## Summary
- Fixes CI failure in `test_car_interfaces` caused by `KeyError: 'RADAR_SUPP_TICK_REFERENCE'`.
- Makes Honda CAN-FD `CarState.update()` robust when the radar supplemental tick frame has not been received yet.
- Makes `supp_tick` pulse on each newly received radar `0x710` frame instead of acting like a sticky level.
- Uses `CS.supp_tick` in `CarController` so supplemental sending follows car-state parsing accurately.

## Changes
- `opendbc/car/honda/carstate.py`
  - Initialize `self.supp_tick = False` and `self.radar_ref_counter = 0` in `__init__`.
  - Detect tick edges via `cp_radar.vl_all["RADAR_SUPP_TICK_REFERENCE"]["IGNORE"]` list length each update cycle.
  - Reset `self.supp_tick` to `False` for non-CANFD paths.
- `opendbc/car/honda/carcontroller.py`
  - Replace `self.supp_tick` with `CS.supp_tick` when deciding to send `BOSCH_SUPPLEMENTAL_CANFD`.

## Why this works
- `vl_all` signal arrays represent messages seen in the current parser update window; checking the `IGNORE` signal list length gives a per-message pulse for `0x710`.
- This avoids both prior failure modes:
  - missing-key crashes in empty-CAN tests,
  - and non-pulsing/sticky behavior during real driving.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abdab9b7-d2a9-4086-bec8-0932b9052a41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abdab9b7-d2a9-4086-bec8-0932b9052a41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

