### PR TITLE
Fix Honda CAN-FD radar look-alikes: supp_tick + MUX cycle

### DIFF
--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -214,7 +214,7 @@ class CarController(CarControllerBase):
     if (self.CP.carFingerprint in HONDA_BOSCH_CANFD) and self.CP.openpilotLongitudinalControl:
       if self.frame % 10 == 0:
         can_sends.append(hondacan.create_radar_hud_canfd(self.packer, self.CAN.pt, CC.enabled))
-      if self.supp_tick:
+      if CS.supp_tick:
         can_sends.append(hondacan.create_canfd_supplemental(self.packer, self.CAN.pt))
       if self.frame % 2 == 0:
         if self.radar_mux == 10:

--- a/opendbc/car/honda/carstate.py
+++ b/opendbc/car/honda/carstate.py
@@ -285,6 +285,8 @@ class CarState(CarStateBase):
     if CP.enableBsm:
       parsers[Bus.body] = CANParser(DBC[CP.carFingerprint][Bus.body], [], CanBus(CP).radar)
     if self.CP.carFingerprint in HONDA_BOSCH_CANFD:
-      parsers[Bus.radar] = CANParser(DBC[CP.carFingerprint][Bus.radar], [], CanBus(CP).radar)
+      # RADAR_SUPP_TICK_REFERENCE (0x710) must be explicitly subscribed: it is only read via vl_all,
+      # which (unlike vl) does not auto-subscribe messages, so without this it is never parsed.
+      parsers[Bus.radar] = CANParser(DBC[CP.carFingerprint][Bus.radar], [("RADAR_SUPP_TICK_REFERENCE", 0)], CanBus(CP).radar)
 
     return parsers

--- a/opendbc/car/honda/carstate.py
+++ b/opendbc/car/honda/carstate.py
@@ -257,7 +257,7 @@ class CarState(CarStateBase):
       self.lkas_hud = cp_cam.vl["LKAS_HUD"]
     if self.CP.carFingerprint in HONDA_BOSCH_CANFD:
       self.radar_ref_counter = cp.vl["RADAR_REFERENCE"]["COUNTER"]
-      self.supp_tick = bool(len(cp_radar.vl_all["RADAR_SUPP_TICK_REFERENCE"]) > 0)
+      self.supp_tick = bool(cp_radar.vl_all.get("RADAR_SUPP_TICK_REFERENCE", {}))
 
     if self.CP.enableBsm:
       # BSM messages are on B-CAN, requires a panda forwarding B-CAN messages to CAN 0

--- a/opendbc/car/honda/carstate.py
+++ b/opendbc/car/honda/carstate.py
@@ -55,6 +55,8 @@ class CarState(CarStateBase):
 
     self.initial_accFault_cleared = False
     self.initial_accFault_cleared_timer = int(10 / DT_CTRL) # 10 seconds after startup for initial faults to clear
+    self.radar_ref_counter = 0
+    self.supp_tick = False
 
   def update(self, can_parsers) -> structs.CarState:
     cp = can_parsers[Bus.pt]
@@ -248,7 +250,6 @@ class CarState(CarStateBase):
 
     self.acc_hud = False
     self.lkas_hud = False
-    self.radar_ref_counter = 0
     if self.CP.carFingerprint not in HONDA_BOSCH:
       ret.stockFcw = cp_cam.vl["BRAKE_COMMAND"]["FCW"] != 0
       self.acc_hud = cp_cam.vl["ACC_HUD"]
@@ -257,7 +258,11 @@ class CarState(CarStateBase):
       self.lkas_hud = cp_cam.vl["LKAS_HUD"]
     if self.CP.carFingerprint in HONDA_BOSCH_CANFD:
       self.radar_ref_counter = cp.vl["RADAR_REFERENCE"]["COUNTER"]
-      self.supp_tick = bool(cp_radar.vl_all.get("RADAR_SUPP_TICK_REFERENCE", {}))
+      # Pulse true only on update cycles where a new 0x710 frame was received.
+      supp_tick_vals = cp_radar.vl_all.get("RADAR_SUPP_TICK_REFERENCE", {}).get("IGNORE", [])
+      self.supp_tick = len(supp_tick_vals) > 0
+    else:
+      self.supp_tick = False
 
     if self.CP.enableBsm:
       # BSM messages are on B-CAN, requires a panda forwarding B-CAN messages to CAN 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Validation
* Dongle ID: 3792d010590cb83a
* Route: 3792d010590cb83a/000000f4--f9be0edf56

## Summary
Two fixes so the fabricated CAN-FD radar traffic matches what the stock radar sent, preventing the camera ECU from faulting:

1. Subscribe `RADAR_SUPP_TICK_REFERENCE` (`0x710`) so `supp_tick` actually pulses and `BOSCH_SUPPLEMENTAL_CANFD` is transmitted (previously the radar parser had an empty message list, so `vl_all` never contained it).
2. Fix the `HUD_OBJECTS` / `LANE_PATH` MUX cycle.

## MUX bug (root cause of remaining camera fault)
Decoded the route above and compared the stock radar (relay closed, first ~10 s) against openpilot's fabricated frames (after relay opens):

- Stock radar MUX set: `1-10, 17-26, 33-42, 49-58`
- openpilot MUX set:  `1-10, 18-26, 34-42, 50-58`

openpilot never emitted MUX `17`, `33`, `49` (the first frame of banks 2-4). The cause was sequential `if` statements: setting the bank start (e.g. `radar_mux = 17`) fell through to the `else: radar_mux += 1`, bumping it to `18` before sending. The camera cycles all MUX slots and sees those three never update -> fault.

Fixed by making the branches mutually exclusive (`elif`) and checking the wrap first. Verified the resulting sequence now equals the stock radar's set exactly.

## Verification
- Rates already matched stock radar: `RADAR_HUD_CANFD` 10 Hz, `LANE_PATH`/`HUD_OBJECTS` 50 Hz, `RADAR_LEAD`/`RADAR_LEAD2` 5 Hz, `BOSCH_SUPPLEMENTAL_CANFD` 1 Hz.
- Simulated the fixed MUX logic: distinct values now `1-10, 17-26, 33-42, 49-58` (matches stock radar decoded from the log).

## Files
- `opendbc/car/honda/carstate.py`
- `opendbc/car/honda/carcontroller.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abdab9b7-d2a9-4086-bec8-0932b9052a41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abdab9b7-d2a9-4086-bec8-0932b9052a41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

