### PR TITLE
Match stock Honda radar RADAR_LEAD target speed (140)

### DIFF
--- a/opendbc/car/honda/hondacan.py
+++ b/opendbc/car/honda/hondacan.py
@@ -291,7 +291,8 @@ def create_canfd_5hz_radar_messages(packer, bus, radar_ref_cntr):
   radar_lead_values = {
     'CNTR_REF': radar_ref_cntr,
     'SET_ME_X01': 0x01,
-    'TARGET_SPEED_MAYBE': 120,
+    # stock radar transmits a constant 140 here (confirmed from logs); 120 causes a camera mismatch
+    'TARGET_SPEED_MAYBE': 140,
     'LEAD_DISTANCE_MAYBE': 6,
   }
   commands.append(packer.make_can_msg('RADAR_LEAD', bus, radar_lead_values))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Validation
* Dongle ID: 3792d010590cb83a
* Route: 3792d010590cb83a/000000f5--88bca68a02

## Summary
Follow-up to the CAN-FD radar look-alike fixes. Decoded the new route and compared every fabricated radar message (stock radar, relay closed for first ~7 s) against openpilot's frames after the relay opens.

Results:
- MUX cycle now matches the stock radar exactly (`1-10, 17-26, 33-42, 49-58`).
- `RADAR_HUD_CANFD`, `RADAR_LEAD2`, `BOSCH_SUPPLEMENTAL_CANFD` payloads match.
- Full address-set diff: no radar-origin message is missing.
- **`RADAR_LEAD` differed**: stock radar transmits `TARGET_SPEED_MAYBE = 140` (byte1 `0x8c`), openpilot hardcoded `120` (`0x78`). Confirmed constant `140` across two separate drives (f4 and f5), independent of vehicle speed.

## Fix
Set `RADAR_LEAD.TARGET_SPEED_MAYBE` to `140` in `create_canfd_5hz_radar_messages` to match the stock radar.

## Files
- `opendbc/car/honda/hondacan.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abdab9b7-d2a9-4086-bec8-0932b9052a41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abdab9b7-d2a9-4086-bec8-0932b9052a41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

