### PR TITLE
Send Honda CAN-FD radar look-alikes on both buses (camera + powertrain)

### DIFF
--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -211,14 +211,17 @@ class CarController(CarControllerBase):
         can_sends.append(make_tester_present_msg(0x18DAB0F1, bus, suppress_response=True))
 
     # simulate canfd radar to prevent faults
-    # These radar look-alikes are consumed by the camera ECU, which sits behind the relay on the
-    # camera bus. openpilot's own transmissions are not forwarded across the open relay, so they
-    # must be sent directly on the camera bus (not the powertrain/radar bus) to reach the camera.
+    # These radar look-alikes are consumed by both the camera ECU (behind the relay, on the camera
+    # bus) and the powertrain (radar bus). openpilot's own transmissions are not forwarded across the
+    # open relay, so they must be sent explicitly on both buses. Each message is packed exactly once
+    # so the packer's counter/checksum only advance once per cycle, then the identical bytes are
+    # mirrored onto both buses (re-packing would double-increment the counter and desync the buses).
     if (self.CP.carFingerprint in HONDA_BOSCH_CANFD) and self.CP.openpilotLongitudinalControl:
+      radar_msgs = []
       if self.frame % 10 == 0:
-        can_sends.append(hondacan.create_radar_hud_canfd(self.packer, self.CAN.camera, CC.enabled))
+        radar_msgs.append(hondacan.create_radar_hud_canfd(self.packer, self.CAN.pt, CC.enabled))
       if CS.supp_tick:
-        can_sends.append(hondacan.create_canfd_supplemental(self.packer, self.CAN.camera))
+        radar_msgs.append(hondacan.create_canfd_supplemental(self.packer, self.CAN.pt))
       if self.frame % 2 == 0:
         # Cycle the radar MUX through the same banks the stock radar uses: 1-10, 17-26, 33-42, 49-58.
         # These must be elif (not sequential if): a bare `if` that sets the bank start would fall
@@ -233,9 +236,14 @@ class CarController(CarControllerBase):
           self.radar_mux = 49
         else:
           self.radar_mux += 1
-        can_sends.extend(hondacan.create_canfd_50hz_radar_messages(self.packer, self.CAN.camera, self.radar_mux))
+        radar_msgs.extend(hondacan.create_canfd_50hz_radar_messages(self.packer, self.CAN.pt, self.radar_mux))
       if self.frame % 20 == 0:
-        can_sends.extend(hondacan.create_canfd_5hz_radar_messages(self.packer, self.CAN.camera, CS.radar_ref_counter))
+        radar_msgs.extend(hondacan.create_canfd_5hz_radar_messages(self.packer, self.CAN.pt, CS.radar_ref_counter))
+
+      # mirror each packed frame onto both the powertrain bus and the camera bus
+      for addr, dat, _ in radar_msgs:
+        can_sends.append((addr, dat, self.CAN.pt))
+        can_sends.append((addr, dat, self.CAN.camera))
 
     # Send steering command.
     can_sends.append(hondacan.create_steering_control(self.packer, self.CAN, apply_torque, CC.latActive, self.tja_control))

--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -211,11 +211,14 @@ class CarController(CarControllerBase):
         can_sends.append(make_tester_present_msg(0x18DAB0F1, bus, suppress_response=True))
 
     # simulate canfd radar to prevent faults
+    # These radar look-alikes are consumed by the camera ECU, which sits behind the relay on the
+    # camera bus. openpilot's own transmissions are not forwarded across the open relay, so they
+    # must be sent directly on the camera bus (not the powertrain/radar bus) to reach the camera.
     if (self.CP.carFingerprint in HONDA_BOSCH_CANFD) and self.CP.openpilotLongitudinalControl:
       if self.frame % 10 == 0:
-        can_sends.append(hondacan.create_radar_hud_canfd(self.packer, self.CAN.pt, CC.enabled))
+        can_sends.append(hondacan.create_radar_hud_canfd(self.packer, self.CAN.camera, CC.enabled))
       if CS.supp_tick:
-        can_sends.append(hondacan.create_canfd_supplemental(self.packer, self.CAN.pt))
+        can_sends.append(hondacan.create_canfd_supplemental(self.packer, self.CAN.camera))
       if self.frame % 2 == 0:
         # Cycle the radar MUX through the same banks the stock radar uses: 1-10, 17-26, 33-42, 49-58.
         # These must be elif (not sequential if): a bare `if` that sets the bank start would fall
@@ -230,9 +233,9 @@ class CarController(CarControllerBase):
           self.radar_mux = 49
         else:
           self.radar_mux += 1
-        can_sends.extend(hondacan.create_canfd_50hz_radar_messages(self.packer, self.CAN.pt, self.radar_mux))
+        can_sends.extend(hondacan.create_canfd_50hz_radar_messages(self.packer, self.CAN.camera, self.radar_mux))
       if self.frame % 20 == 0:
-        can_sends.extend(hondacan.create_canfd_5hz_radar_messages(self.packer, self.CAN.pt, CS.radar_ref_counter))
+        can_sends.extend(hondacan.create_canfd_5hz_radar_messages(self.packer, self.CAN.camera, CS.radar_ref_counter))
 
     # Send steering command.
     can_sends.append(hondacan.create_steering_control(self.packer, self.CAN, apply_torque, CC.latActive, self.tja_control))

--- a/opendbc/safety/modes/honda.h
+++ b/opendbc/safety/modes/honda.h
@@ -348,10 +348,13 @@ static safety_config honda_bosch_init(uint16_t param) {
 
   static CanMsg HONDA_CANFD_TX_MSGS[] = {{0xE4, 0, 5, .check_relay = true}, {0x296, 0, 4, .check_relay = false}, {0x33D, 0, 8, .check_relay = true}}; // Bosch CANFD
 
+  // The radar look-alikes (0x310, 0x6CD5558, 0x6CD5559, 0xF31AA52, 0xF31AA5C, 0x1A45AA4E) are consumed by the
+  // camera, which is behind the relay on the camera bus (2). openpilot TX is not forwarded across the open relay,
+  // so these must be sent on bus 2 to reach the camera; the powertrain control messages stay on bus 0.
   static CanMsg HONDA_CANFD_LONG_TX_MSGS[] = {{0xE4, 0, 5, .check_relay = true}, {0x1DF, 0, 8, .check_relay = true}, {0x1EF, 0, 8, .check_relay = false},
                                               {0x30C, 0, 8, .check_relay = false}, {0x33D, 0, 8, .check_relay = true}, {0x18DAB0F1, 0, 8, .check_relay = false},
-                                              {0x310, 0, 8, .check_relay = false}, {0x6CD5558, 0, 8, .check_relay = true}, {0x6CD5559, 0, 8, .check_relay = false},
-                                              {0xF31AA52, 0, 8, .check_relay = false}, {0xF31AA5C, 0, 8, .check_relay = true}, {0x1A45AA4E, 0, 8, .check_relay = false}};
+                                              {0x310, 2, 8, .check_relay = false}, {0x6CD5558, 2, 8, .check_relay = true}, {0x6CD5559, 2, 8, .check_relay = false},
+                                              {0xF31AA52, 2, 8, .check_relay = false}, {0xF31AA5C, 2, 8, .check_relay = true}, {0x1A45AA4E, 2, 8, .check_relay = false}};
 
   const uint16_t HONDA_PARAM_ALT_BRAKE = 1;
   const uint16_t HONDA_PARAM_RADARLESS = 8;

--- a/opendbc/safety/modes/honda.h
+++ b/opendbc/safety/modes/honda.h
@@ -348,11 +348,13 @@ static safety_config honda_bosch_init(uint16_t param) {
 
   static CanMsg HONDA_CANFD_TX_MSGS[] = {{0xE4, 0, 5, .check_relay = true}, {0x296, 0, 4, .check_relay = false}, {0x33D, 0, 8, .check_relay = true}}; // Bosch CANFD
 
-  // The radar look-alikes (0x310, 0x6CD5558, 0x6CD5559, 0xF31AA52, 0xF31AA5C, 0x1A45AA4E) are consumed by the
-  // camera, which is behind the relay on the camera bus (2). openpilot TX is not forwarded across the open relay,
-  // so these must be sent on bus 2 to reach the camera; the powertrain control messages stay on bus 0.
+  // The radar look-alikes (0x310, 0x6CD5558, 0x6CD5559, 0xF31AA52, 0xF31AA5C, 0x1A45AA4E) are consumed by both
+  // the camera (behind the relay on the camera bus, 2) and the powertrain (radar bus, 0). openpilot TX is not
+  // forwarded across the open relay, so each is sent on both buses; the control messages stay on bus 0.
   static CanMsg HONDA_CANFD_LONG_TX_MSGS[] = {{0xE4, 0, 5, .check_relay = true}, {0x1DF, 0, 8, .check_relay = true}, {0x1EF, 0, 8, .check_relay = false},
                                               {0x30C, 0, 8, .check_relay = false}, {0x33D, 0, 8, .check_relay = true}, {0x18DAB0F1, 0, 8, .check_relay = false},
+                                              {0x310, 0, 8, .check_relay = false}, {0x6CD5558, 0, 8, .check_relay = true}, {0x6CD5559, 0, 8, .check_relay = false},
+                                              {0xF31AA52, 0, 8, .check_relay = false}, {0xF31AA5C, 0, 8, .check_relay = true}, {0x1A45AA4E, 0, 8, .check_relay = false},
                                               {0x310, 2, 8, .check_relay = false}, {0x6CD5558, 2, 8, .check_relay = true}, {0x6CD5559, 2, 8, .check_relay = false},
                                               {0xF31AA52, 2, 8, .check_relay = false}, {0xF31AA5C, 2, 8, .check_relay = true}, {0x1A45AA4E, 2, 8, .check_relay = false}};
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Validation
* Dongle ID: 3792d010590cb83a
* Route: 3792d010590cb83a/000000f6--9a334e998e

## Root cause
The camera ECU sits behind the comma relay on the **camera bus (2)**; radar/powertrain are on **bus 0**. openpilot transmitted the fabricated radar messages only on bus 0, and `safety_fwd_hook` forwards only *physically received* messages across the open relay — never openpilot's own TX. Decoding the route confirmed that after the relay opens the camera receives none of the six radar look-alikes (`RADAR_HUD_CANFD`, `LANE_PATH`, `HUD_OBJECTS`, `RADAR_LEAD`, `RADAR_LEAD2`, `BOSCH_SUPPLEMENTAL_CANFD`) on either its physical bus or the forwarded path, while the stock radar's frames did reach it before cutover. That total loss of radar data is what the camera faults on.

## Fix
Transmit the six radar look-alikes on **both** buses (camera + powertrain), since both consume them and neither direction is covered by relay forwarding:

- `carcontroller.py`: pack each radar message **exactly once**, then mirror the identical bytes onto `self.CAN.pt` (bus 0) and `self.CAN.camera` (bus 2).
- `safety/modes/honda.h`: allow the six radar addresses on both bus 0 and bus 2 in `HONDA_CANFD_LONG_TX_MSGS`; control messages stay on bus 0.

## Counter/checksum double-increment
`CANPacker` bumps the counter on every `pack()` call, so re-packing per bus would advance the counter twice per cycle and desync the two buses. Instead each frame is packed once and the same bytes are sent to both buses. Verified:

```
cyc0 bus0 RADAR_LEAD cnt=0 bytes=208c00180000000b
cyc0 bus2 RADAR_LEAD cnt=0 bytes=208c00180000000b
cyc1 bus0 RADAR_LEAD cnt=1 ...
cyc3 ... cnt=3 ; cyc4 ... cnt=0
```
Counter advances once per cycle and both buses carry identical counter + checksum.

## Validation
- `libsafety` compiles cleanly.
- Honda safety suite: **344 failed with and without the change** — all in the pre-existing WIP `TestHondaBoschCANFDLongSafety` class; no new regressions from this edit. Those pre-existing CAN-FD-long safety-test failures should be resolved separately before shipping.

## Files
- `opendbc/car/honda/carcontroller.py`
- `opendbc/safety/modes/honda.h`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abdab9b7-d2a9-4086-bec8-0932b9052a41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abdab9b7-d2a9-4086-bec8-0932b9052a41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

