### PR TITLE
Match stock Honda radar LANE_PATH/HUD_OBJECTS empty payloads

### DIFF
--- a/opendbc/car/honda/hondacan.py
+++ b/opendbc/car/honda/hondacan.py
@@ -259,26 +259,46 @@ def create_canfd_supplemental(packer, bus):
   return packer.make_can_msg("BOSCH_SUPPLEMENTAL_CANFD", bus, values)
 
 
+# Radar MUX banks: 1-10, 17-26, 33-42, 49-58. Each bank is a fresh sweep of path points.
+RADAR_MUX_BANK_STARTS = (1, 17, 33, 49)
+# "no detection" sentinel the stock radar uses for an empty path point / object slot
+PATH_OFFSET_INVALID = 2047
+
+
+def _lane_path_offsets(radar_mux):
+  # The stock radar reports path points as a sweep within each MUX bank: the first point (bank start)
+  # is 0, the second has the first two offsets valid (0) and the rest invalid, and the remaining points
+  # are fully invalid. Match that exact per-MUX pattern so the camera sees a consistent empty path.
+  pos = next((radar_mux - start for start in RADAR_MUX_BANK_STARTS if start <= radar_mux <= start + 9), 0)
+  if pos == 0:
+    return (0, 0, 0, 0)
+  if pos == 1:
+    return (0, 0, PATH_OFFSET_INVALID, PATH_OFFSET_INVALID)
+  return (PATH_OFFSET_INVALID,) * 4
+
+
 def create_canfd_50hz_radar_messages(packer, bus, radar_mux):
   commands = []
 
+  offsets = _lane_path_offsets(radar_mux)
   lane_path_values = {
     'MUX': radar_mux,
-    'PATH_OFFSET_1': 0,
-    'PATH_OFFSET_2': 0,
-    'PATH_OFFSET_3': 0,
-    'PATH_OFFSET_4': 0,
+    'PATH_OFFSET_1': offsets[0],
+    'PATH_OFFSET_2': offsets[1],
+    'PATH_OFFSET_3': offsets[2],
+    'PATH_OFFSET_4': offsets[3],
   }
   commands.append(packer.make_can_msg('LANE_PATH', bus, lane_path_values))
 
+  # Empty-object-slot sentinel the stock radar transmits (no lead/object): max distances, CAR_TYPE=-1.
   hud_objects_values = {
     'MUX': radar_mux,
     'OBJECT_ID': 0,
     'IS_LEAD_CAR': 0,
-    'CAR_TYPE': 0,
-    'ROTATION': 0,
-    'LONG_DIST': 0,
-    'LAT_DIST': 0,
+    'CAR_TYPE': -1,
+    'ROTATION': -128,
+    'LONG_DIST': 196.9,
+    'LAT_DIST': 204.7,
   }
   commands.append(packer.make_can_msg('HUD_OBJECTS', bus, hud_objects_values))
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Validation
* Dongle ID: 3792d010590cb83a
* Route: 3792d010590cb83a/000000f7--b894cafe91

## Context
With the dual-bus routing fix in place, the camera now receives all six radar look-alikes (confirmed: on `bus130`/`bus128` after cutover). But it still faulted, so I compared the **payload content** per MUX against the stock radar.

## Finding
openpilot sent all-zero payloads for `LANE_PATH`/`HUD_OBJECTS`, but the stock radar transmits fixed "no-detection" sentinels (consistent regardless of driving):

- `HUD_OBJECTS` (every MUX): `00 f0 80 ff c7 ff` — `CAR_TYPE=-1`, `ROTATION=-128`, `LONG_DIST=196.9` (max), `LAT_DIST=204.7` (max). openpilot sent `00 00 00 14 40 00`.
- `LANE_PATH` (per MUX position within each bank):
  - bank start (1/17/33/49): `00 00 00 00 00 00` (offsets 0)
  - second (2/18/34/50): `00 00 00 7f f7 ff` (offsets 1,2 = 0; 3,4 = 0x7FF)
  - remaining: `7f f7 ff 7f f7 ff` (all offsets = 0x7FF invalid sentinel)

  openpilot sent all zeros for every MUX, i.e. it told the camera "valid lane centered at 0 / object at 0 m," conflicting with the camera's own vision.

## Fix
Set `create_canfd_50hz_radar_messages` to emit the stock sentinel values:
- `HUD_OBJECTS`: `CAR_TYPE=-1`, `ROTATION=-128`, `LONG_DIST=196.9`, `LAT_DIST=204.7`.
- `LANE_PATH`: per-MUX offsets matching the bank-position pattern (`0` / half / `2047`).

## Verification
Packed every MUX in the cycle (1-10, 17-26, 33-42, 49-58) and confirmed the produced `LANE_PATH`/`HUD_OBJECTS` payload bytes match the stock radar decoded from the log exactly (0 mismatches).

## Files
- `opendbc/car/honda/hondacan.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abdab9b7-d2a9-4086-bec8-0932b9052a41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abdab9b7-d2a9-4086-bec8-0932b9052a41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

