### PR TITLE
Honda CAN-FD: clear stale DTCs (radar + global) on disable, hide radar diagnostics from camera

### DIFF
--- a/opendbc/car/disable_ecu.py
+++ b/opendbc/car/disable_ecu.py
@@ -1,3 +1,4 @@
+from opendbc.car.can_definitions import CanData
 from opendbc.car.carlog import carlog
 from opendbc.car.isotp_parallel_query import IsoTpParallelQuery
 
@@ -9,6 +10,26 @@ COM_CONT_RESPONSE = b''
 # UDS 0x14 ClearDiagnosticInformation for all DTC groups (0xFFFFFF), positive response 0x54
 CLEAR_DTC_REQUEST = b'\x14\xff\xff\xff'
 CLEAR_DTC_RESPONSE = b'\x54'
+
+# 29-bit functional (broadcast) diagnostic address; targets every ECU on the bus
+FUNCTIONAL_ADDR_29BIT = 0x18DB33F1
+# ISO-TP single frame carrying CLEAR_DTC_REQUEST (0x14 ClearDiagnosticInformation, all groups)
+CLEAR_DTC_ISOTP_SF = bytes([len(CLEAR_DTC_REQUEST)]) + CLEAR_DTC_REQUEST + b'\x00' * (7 - len(CLEAR_DTC_REQUEST))
+
+
+def clear_all_dtcs(can_send, buses, functional_addr=FUNCTIONAL_ADDR_29BIT):
+  """Broadcast UDS 0x14 ClearDiagnosticInformation (all DTC groups) to every ECU on the given buses
+  using the functional (broadcast) address. Best-effort; no responses are collected.
+
+  This is used to clear stored DTCs that other ECUs may have latched due to a disabled radar, so they
+  don't report stale faults on a later drive.
+
+  WARNING: this clears stored DTCs on ALL ECUs on the bus, including unrelated and safety-relevant
+  modules, so genuine fault codes are erased too. Only use it when you specifically need to clear
+  cross-ECU faults."""
+  for bus in buses:
+    carlog.warning(f"clear all DTCs (functional) on bus {bus} ...")
+    can_send([CanData(functional_addr, CLEAR_DTC_ISOTP_SF, bus)])
 
 
 def disable_ecu(can_recv, can_send, bus=0, addr=0x7d0, sub_addr=None, com_cont_req=b'\x28\x83\x01', timeout=0.1, retry=10, clear_dtc=False):

--- a/opendbc/car/disable_ecu.py
+++ b/opendbc/car/disable_ecu.py
@@ -6,13 +6,21 @@ EXT_DIAG_RESPONSE = b'\x50\x03'
 
 COM_CONT_RESPONSE = b''
 
+# UDS 0x14 ClearDiagnosticInformation for all DTC groups (0xFFFFFF), positive response 0x54
+CLEAR_DTC_REQUEST = b'\x14\xff\xff\xff'
+CLEAR_DTC_RESPONSE = b'\x54'
 
-def disable_ecu(can_recv, can_send, bus=0, addr=0x7d0, sub_addr=None, com_cont_req=b'\x28\x83\x01', timeout=0.1, retry=10):
+
+def disable_ecu(can_recv, can_send, bus=0, addr=0x7d0, sub_addr=None, com_cont_req=b'\x28\x83\x01', timeout=0.1, retry=10, clear_dtc=False):
   """Silence an ECU by disabling sending and receiving messages using UDS 0x28.
   The ECU will stay silent as long as openpilot keeps sending Tester Present.
 
   This is used to disable the radar in some cars. Openpilot will emulate the radar.
-  WARNING: THIS DISABLES AEB!"""
+  WARNING: THIS DISABLES AEB!
+
+  When clear_dtc is set, stored DTCs are cleared (UDS 0x14) after entering the extended
+  diagnostic session and before disabling communication. This prevents stale fault codes
+  accumulated while the ECU was disabled from being reported on a later drive."""
   carlog.warning(f"ecu disable {hex(addr), sub_addr} ...")
 
   for i in range(retry):
@@ -20,6 +28,12 @@ def disable_ecu(can_recv, can_send, bus=0, addr=0x7d0, sub_addr=None, com_cont_r
       query = IsoTpParallelQuery(can_send, can_recv, bus, [(addr, sub_addr)], [EXT_DIAG_REQUEST], [EXT_DIAG_RESPONSE])
 
       for _, _ in query.get_data(timeout).items():
+        # clear stored DTCs while the ECU can still process requests (before disabling comms)
+        if clear_dtc:
+          carlog.warning("clear diagnostic information ...")
+          query = IsoTpParallelQuery(can_send, can_recv, bus, [(addr, sub_addr)], [CLEAR_DTC_REQUEST], [CLEAR_DTC_RESPONSE])
+          query.get_data(timeout)
+
         carlog.warning("communication control disable tx/rx ...")
 
         query = IsoTpParallelQuery(can_send, can_recv, bus, [(addr, sub_addr)], [com_cont_req], [COM_CONT_RESPONSE])

--- a/opendbc/car/honda/interface.py
+++ b/opendbc/car/honda/interface.py
@@ -2,7 +2,7 @@
 import numpy as np
 from opendbc.car import get_safety_config, structs, uds
 from opendbc.car.common.conversions import Conversions as CV
-from opendbc.car.disable_ecu import disable_ecu
+from opendbc.car.disable_ecu import disable_ecu, clear_all_dtcs
 from opendbc.car.honda.hondacan import CanBus
 from opendbc.car.honda.values import CarControllerParams, HondaFlags, CAR, HONDA_BOSCH, HONDA_BOSCH_CANFD, \
                                                  HONDA_NIDEC_ALT_SCM_MESSAGES, HONDA_BOSCH_RADARLESS, HondaSafetyFlags
@@ -340,6 +340,10 @@ class CarInterface(CarInterfaceBase):
         # previous drive don't fault the brake module at startup.
         clear_dtc = CP.carFingerprint in HONDA_BOSCH_CANFD
       disable_ecu(can_recv, can_send, bus=CanBus(CP).pt, addr=0x18DAB0F1, com_cont_req=communication_control, clear_dtc=clear_dtc)
+      if clear_dtc:
+        # Also clear DTCs on the other ECUs (powertrain and camera buses) that may have latched a
+        # fault from the missing radar, so they don't report stale codes on a later drive.
+        clear_all_dtcs(can_send, [CanBus(CP).pt, CanBus(CP).camera])
 
   @staticmethod
   def deinit(CP, can_recv, can_send):

--- a/opendbc/car/honda/interface.py
+++ b/opendbc/car/honda/interface.py
@@ -332,10 +332,14 @@ class CarInterface(CarInterfaceBase):
   def init(CP, can_recv, can_send, communication_control=None):
     if CP.carFingerprint in (HONDA_BOSCH - HONDA_BOSCH_RADARLESS) and CP.openpilotLongitudinalControl:
       # 0x80 silences response
+      clear_dtc = False
       if communication_control is None:
         communication_control = bytes([uds.SERVICE_TYPE.COMMUNICATION_CONTROL, 0x80 | uds.CONTROL_TYPE.DISABLE_RX_DISABLE_TX,
                                        uds.MESSAGE_TYPE.NORMAL_AND_NETWORK_MANAGEMENT])
-      disable_ecu(can_recv, can_send, bus=CanBus(CP).pt, addr=0x18DAB0F1, com_cont_req=communication_control)
+        # The CAN FD radar stores DTCs while disabled; clear them on disable so stale codes from a
+        # previous drive don't fault the brake module at startup.
+        clear_dtc = CP.carFingerprint in HONDA_BOSCH_CANFD
+      disable_ecu(can_recv, can_send, bus=CanBus(CP).pt, addr=0x18DAB0F1, com_cont_req=communication_control, clear_dtc=clear_dtc)
 
   @staticmethod
   def deinit(CP, can_recv, can_send):

--- a/opendbc/safety/modes/honda.h
+++ b/opendbc/safety/modes/honda.h
@@ -356,7 +356,9 @@ static safety_config honda_bosch_init(uint16_t param) {
                                               {0x310, 0, 8, .check_relay = false}, {0x6CD5558, 0, 8, .check_relay = true}, {0x6CD5559, 0, 8, .check_relay = false},
                                               {0xF31AA52, 0, 8, .check_relay = false}, {0xF31AA5C, 0, 8, .check_relay = true}, {0x1A45AA4E, 0, 8, .check_relay = false},
                                               {0x310, 2, 8, .check_relay = false}, {0x6CD5558, 2, 8, .check_relay = true}, {0x6CD5559, 2, 8, .check_relay = false},
-                                              {0xF31AA52, 2, 8, .check_relay = false}, {0xF31AA5C, 2, 8, .check_relay = true}, {0x1A45AA4E, 2, 8, .check_relay = false}};
+                                              {0xF31AA52, 2, 8, .check_relay = false}, {0xF31AA5C, 2, 8, .check_relay = true}, {0x1A45AA4E, 2, 8, .check_relay = false},
+                                              // functional (broadcast) diagnostic address, used to clear stale DTCs on radar disable (both buses)
+                                              {0x18DB33F1, 0, 8, .check_relay = false}, {0x18DB33F1, 2, 8, .check_relay = false}};
 
   const uint16_t HONDA_PARAM_ALT_BRAKE = 1;
   const uint16_t HONDA_PARAM_RADARLESS = 8;

--- a/opendbc/safety/modes/honda.h
+++ b/opendbc/safety/modes/honda.h
@@ -444,6 +444,19 @@ static bool honda_nidec_fwd_hook(int bus_num, int addr) {
   return block_msg;
 }
 
+static bool honda_bosch_fwd_hook(int bus_num, int addr) {
+  bool block_msg = false;
+
+  // On CAN FD Bosch, openpilot disables the radar by holding it in a diagnostic session. Don't forward
+  // the radar's diagnostic responses (0x18DAF1B0, radar 0xB0 -> tester 0xF1) from the radar bus to the
+  // camera bus, so the camera can't observe openpilot silencing the radar and raise a radar (RDM) fault.
+  if (honda_bosch_canfd && (bus_num == 0) && (addr == 0x18DAF1B0)) {
+    block_msg = true;
+  }
+
+  return block_msg;
+}
+
 const safety_hooks honda_nidec_hooks = {
   .init = honda_nidec_init,
   .rx = honda_rx_hook,
@@ -458,6 +471,7 @@ const safety_hooks honda_bosch_hooks = {
   .init = honda_bosch_init,
   .rx = honda_rx_hook,
   .tx = honda_tx_hook,
+  .fwd = honda_bosch_fwd_hook,
   .get_counter = honda_get_counter,
   .get_checksum = honda_get_checksum,
   .compute_checksum = honda_compute_checksum,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Mitigations for the CAN-FD Bosch radar-disable interaction with other ECUs (persistent "two-drive" faults) and the camera.

## 1. Clear stored DTCs on radar disable
The CAN-FD radar (and other ECUs that consume radar data) latch DTCs while the radar is disabled. These persist across drives and get reported at startup (e.g. blocking the brake module).

- `disable_ecu()` gains an opt-in `clear_dtc` param: sends UDS `0x14 ClearDiagnosticInformation` (all groups, `14 ff ff ff`) to the radar after entering the extended session and before disabling comms.
- New `clear_all_dtcs(can_send, buses)` broadcasts the same clear to **every ECU** via the 29-bit functional address `0x18DB33F1` (ISO-TP SF `04 14 ff ff ff`), best-effort. Used to clear cross-ECU faults from the missing radar.
- `honda/interface.py::init()` (CAN-FD, disable path only): clears the radar's DTCs and broadcasts a global clear on both the powertrain and camera buses.
- `safety/modes/honda.h`: allow `0x18DB33F1` TX on bus 0 and bus 2 in the CAN-FD long TX list.

WARNING: the global broadcast clear erases stored DTCs on ALL ECUs on those buses, including unrelated/safety modules, so genuine fault codes are cleared too. It's gated to CAN-FD Bosch and only on the disable path.

## 2. Hide the radar's diagnostic responses from the camera
Bosch forwarding hook (CAN-FD-gated) blocks the radar's UDS responses `0x18DAF1B0` from being forwarded radar bus (0) -> camera bus (2), so the camera doesn't observe openpilot silencing the radar and raise a radar (RDM) fault.

## Validation
- `disable_ecu`/`clear_all_dtcs` import cleanly; broadcast frame `0414ffffff000000` to `0x18DB33F1`.
- `libsafety` compiles; Honda safety suite unchanged (344 pre-existing WIP `TestHondaBoschCANFDLongSafety` failures with and without these changes; CAN-FD-gated, non-CAN-FD Bosch unaffected). No new regressions.

## Files
- `opendbc/car/disable_ecu.py`
- `opendbc/car/honda/interface.py`
- `opendbc/safety/modes/honda.h`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abdab9b7-d2a9-4086-bec8-0932b9052a41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abdab9b7-d2a9-4086-bec8-0932b9052a41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

