### PR TITLE
Fix "Unknown Vehicle Variant" (canError) on CAN FD cars: skip camera HUD_OBJECTS polling, send lead-only HUD_OBJECTS

### DIFF
--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -411,7 +411,9 @@ class CarController(CarControllerBase):
       mux = lane_path.MUX_CYCLE[(self.frame // 2) % len(lane_path.MUX_CYCLE)]
       can_sends.append(lane_path.create_lane_path(self.packer, self.CAN.lkas, self.dash_lane.offsets, mux))
 
-      tracks = CS.hud_object_tracker.snapshot()
+      # CAN FD cars have no camera HUD_OBJECTS to poll (the disabled radar owned it), so there are no
+      # secondary vehicle locations: author OP's lead in slot 0 with the other slots blank (tracks=None).
+      tracks = CS.hud_object_tracker.snapshot() if CS.hud_object_tracker is not None else None
       if self.CP.openpilotLongitudinalControl:
         # For OP long, replace lead car and forward rest of objects
         can_sends.append(self.hud_object_author.create(self.packer, self.CAN.lkas, lead, tracks, mux, now_nanos * 1e-9))

--- a/opendbc/car/honda/carstate.py
+++ b/opendbc/car/honda/carstate.py
@@ -59,7 +59,9 @@ class CarState(CarStateBase):
     self.radar_ref_counter = 0
     self.supp_tick = False
 
-    self.hud_object_tracker = HudObjectTracker() if CP.carFingerprint in (HONDA_BOSCH_RADARLESS | HONDA_BOSCH_CANFD) else None
+    # Only radarless cars have a camera that emits HUD_OBJECTS to poll for secondary vehicle locations.
+    # On CAN FD cars the radar owned HUD_OBJECTS and it is disabled, so there is nothing to track.
+    self.hud_object_tracker = HudObjectTracker() if CP.carFingerprint in HONDA_BOSCH_RADARLESS else None
 
   def update(self, can_parsers) -> structs.CarState:
     cp = can_parsers[Bus.pt]
@@ -284,16 +286,9 @@ class CarState(CarStateBase):
     return ret
 
   def get_can_parsers(self, CP):
-    cam_messages = []
-    if CP.carFingerprint in HONDA_BOSCH_CANFD:
-      # On CAN FD cars, HUD_OBJECTS is a radar look-alike that openpilot itself authors, so it may not be
-      # on the bus at all (e.g. with 50Hz radar message creation disabled). Subscribe with nan frequency so
-      # HudObjectTracker can read it when present without its absence tripping canValid/canError.
-      cam_messages.append(("HUD_OBJECTS", float("nan")))
-
     parsers = {
       Bus.pt: CANParser(DBC[CP.carFingerprint][Bus.pt], [], CanBus(CP).pt),
-      Bus.cam: CANParser(DBC[CP.carFingerprint][Bus.pt], cam_messages, CanBus(CP).camera),
+      Bus.cam: CANParser(DBC[CP.carFingerprint][Bus.pt], [], CanBus(CP).camera),
     }
     if CP.enableBsm:
       parsers[Bus.body] = CANParser(DBC[CP.carFingerprint][Bus.body], [], CanBus(CP).radar)

--- a/opendbc/car/honda/carstate.py
+++ b/opendbc/car/honda/carstate.py
@@ -284,9 +284,16 @@ class CarState(CarStateBase):
     return ret
 
   def get_can_parsers(self, CP):
+    cam_messages = []
+    if CP.carFingerprint in HONDA_BOSCH_CANFD:
+      # On CAN FD cars, HUD_OBJECTS is a radar look-alike that openpilot itself authors, so it may not be
+      # on the bus at all (e.g. with 50Hz radar message creation disabled). Subscribe with nan frequency so
+      # HudObjectTracker can read it when present without its absence tripping canValid/canError.
+      cam_messages.append(("HUD_OBJECTS", float("nan")))
+
     parsers = {
       Bus.pt: CANParser(DBC[CP.carFingerprint][Bus.pt], [], CanBus(CP).pt),
-      Bus.cam: CANParser(DBC[CP.carFingerprint][Bus.pt], [], CanBus(CP).camera),
+      Bus.cam: CANParser(DBC[CP.carFingerprint][Bus.pt], cam_messages, CanBus(CP).camera),
     }
     if CP.enableBsm:
       parsers[Bus.body] = CANParser(DBC[CP.carFingerprint][Bus.body], [], CanBus(CP).radar)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Logs/replays on Honda CAN FD cars fail with the "Unknown Vehicle Variant" alert. That alert text is openpilot's `EventName.canError` (`selfdrive/selfdrived/events.py`), which fires when `CS.canValid` goes false — it's not a fingerprinting problem.

On CAN FD cars, HUD_OBJECTS came from the radar, which is disabled — so there is nothing to poll. But `HudObjectTracker` (enabled for `HONDA_BOSCH_CANFD` in 8a6bc34da) touches `cp_cam.vl["HUD_OBJECTS"]`, which lazily registers HUD_OBJECTS (0x6CD5559) as a **required** message on the camera parser. With 50Hz radar message creation also disabled (f8cd2121d), the message never arrives, `canValid` drops, and openpilot raises `canError`. Same cause behind the `test models` CI failures (`can_invalid_cnt != 0` with stderr full of `CANParser: 0x6cd5559 HUD_OBJECTS not valid (timeout or missing)`).

## Fix

The tracker's purpose on radarless cars is to pull secondary vehicle locations from the camera; CAN FD cars have no such source. So:

- `carstate.py`: gate `HudObjectTracker` back to `HONDA_BOSCH_RADARLESS` only — CAN FD cars no longer poll (or implicitly subscribe to) camera HUD_OBJECTS.
- `carcontroller.py`: pass `tracks=None` when the tracker is absent, so CAN FD cars still send HUD_OBJECTS at 50Hz with OP's lead in slot 0 and the byte-faithful INACTIVE blanks in slots 1-9 (`HudObjectAuthor.create` and `forward_hud_object` already handle `tracks=None`).

Radarless cars are unchanged.

## Verification

- MDX 2025 (`ACURA_MDX_4G_MMR`): tracker is `None`, HUD_OBJECTS is not registered on the camera parser, and `can_valid` stays true through 3s of camera traffic without the message (previously went false).
- Authored frames round-tripped through a CANParser: slot-0 muxes (1, 17) carry the lead (`OBJECT_ID=1`, `IS_LEAD_CAR=1`, smoothed `LONG_DIST`), other muxes carry the INACTIVE sentinel values (`LONG_DIST=196.9`, `LAT_DIST=204.7`, `CAR_TYPE=-1`, `ROTATION=-128`); the stock-ACC forward path also emits blanks without crashing.
- Civic 2022 (radarless) still constructs the tracker.
- `opendbc/car/honda` unit tests, `ruff`, and `ty` pass.

## Note

The other CI failure (`test_panda_safety_tx_cases` rejecting LANE_PATH 0x6CD5558 on bus 0) is a separate, pre-existing issue not addressed here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4b52d00-68fd-4657-a523-bf1a301f0cb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4b52d00-68fd-4657-a523-bf1a301f0cb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

