### PR TITLE
CAN FD: send LANE_PATH as stock-style terminated prefix so the dash draws lane lines

### DIFF
--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -409,7 +409,13 @@ class CarController(CarControllerBase):
       self.dash_lane = self.lane_path_fitter.update(self.model, CS.out.vEgo, lead_d)
       # Important: same mux for lane_path and hud_objects. Lane display freezes if muxes don't match.
       mux = lane_path.MUX_CYCLE[(self.frame // 2) % len(lane_path.MUX_CYCLE)]
-      can_sends.append(lane_path.create_lane_path(self.packer, self.CAN.lkas, self.dash_lane.offsets, mux))
+      if self.CP.carFingerprint in HONDA_BOSCH_CANFD:
+        # No LKAS_HUD_2 on CAN FD: the dash reads the lane length from the stock radar's in-band
+        # terminator, so reshape the path into the terminated-prefix form (see lane_path.py).
+        lane_offsets = lane_path.canfd_lane_offsets(self.dash_lane)
+      else:
+        lane_offsets = self.dash_lane.offsets
+      can_sends.append(lane_path.create_lane_path(self.packer, self.CAN.lkas, lane_offsets, mux))
 
       # CAN FD cars have no camera HUD_OBJECTS to poll (the disabled radar owned it), so there are no
       # secondary vehicle locations: author OP's lead in slot 0 with the other slots blank (tracks=None).

--- a/opendbc/car/honda/lane_path.py
+++ b/opendbc/car/honda/lane_path.py
@@ -52,6 +52,25 @@ def encode_lane_path(x, y):
   return _encode(np.interp(LOOKAHEAD, x, y))
 
 
+# Stock CAN FD radar LANE_PATH behavior (decoded from MDX factory ACC logs with lane lines displayed):
+# the path is always a contiguous valid prefix terminated in-band with OFFSET_UNAVAILABLE, at most 24 of
+# the 40 points are ever valid (typically 22-23), and the "no lane" idle is 6 valid zero offsets — never
+# all-unavailable. There is no LKAS_HUD_2 on this platform, so the dash derives the drawn lane length
+# from the in-band terminator; a never-terminated 40-point path renders nothing.
+CANFD_MAX_VALID_PTS = 23
+CANFD_MIN_VALID_PTS = 6
+CANFD_IDLE_OFFSETS = [0] * CANFD_MIN_VALID_PTS + [OFFSET_UNAVAILABLE] * (NUM_PTS - CANFD_MIN_VALID_PTS)
+
+
+def canfd_lane_offsets(dash_lane) -> list[int]:
+  """Reshape a DashLane's 40 offsets into the stock CAN FD radar form: a terminated valid prefix whose
+  length scales with reach, or the stock idle pattern when there is nothing to draw."""
+  if dash_lane.reach <= 0.0 or dash_lane.offsets[0] == OFFSET_UNAVAILABLE:
+    return CANFD_IDLE_OFFSETS
+  n_valid = max(CANFD_MIN_VALID_PTS, min(CANFD_MAX_VALID_PTS, round(dash_lane.reach * CANFD_MAX_VALID_PTS)))
+  return list(dash_lane.offsets[:n_valid]) + [OFFSET_UNAVAILABLE] * (NUM_PTS - n_valid)
+
+
 def create_lane_path(packer, bus, offsets, mux):
   """Pack one LANE_PATH frame for `mux` (one of MUX_CYCLE) from the 40-offset array."""
   base = ((mux - 1) % 16) * OFFSETS_PER_INDEX


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On CAN FD cars (MDX 2025), the dash renders openpilot's lead car but not the lane lines.

Diagnosed from two on-car logs: `3792d010590cb83a/00000101--dc196c6366` (openpilot driving) and `3792d010590cb83a/00000107--49f1de4d88` (factory ACC with lane lines displayed on the dash).

What the openpilot log shows is that transmission is fine:
- LANE_PATH (0x6CD5558) goes out at a steady 50Hz on bus 0, cycling all 40 mux values evenly, with real offsets in ~98% of highway frames.
- Mux is perfectly synced with HUD_OBJECTS (2999 pairs checked, zero mismatches), and the dash demonstrably accepts our frames on this bus/checksum since the lead icon renders.

What the factory ACC log shows is a structural mismatch in the path encoding:
- Across ~1200 stock sweeps, the radar **always** sends the path as a contiguous valid prefix terminated in-band with 2047: at most 24 of 40 points valid (mode 22-23 while driving with lanes displayed), and a 6-point all-zero prefix when idle — never all-unavailable, never a valid point after a 2047.
- openpilot sent all 40 points valid with no terminator (or all-2047 when blank).
- Unlike radarless cars, this platform has no LKAS_HUD_2 (0xF31AA54 appears nowhere in either log) to carry LANE_LENGTH — the dash derives the drawn lane length from the in-band terminator, so a never-terminated path renders nothing.

Ruled out from the factory log: camera LKAS_HUD lane bits (identical to what openpilot already sends), 0x6CD5555 (constant even with lanes displayed), RADAR_LEAD byte deltas (track lead distance/target speed, not lanes).

## Fix

New `canfd_lane_offsets()` in `lane_path.py` reshapes the DashLane offsets into the stock form for CAN FD cars only:
- valid prefix length scaled by `reach`, clamped to 6..23 points, terminated with 2047;
- the stock 6-zero idle pattern when there is nothing to draw.

Our idle frames now byte-match the factory log's idle sweep exactly (`04000000000000`, `080000007ff7ff`, `0c7ff7ff7ff7ff`, ...). Radarless cars are unchanged (LKAS_HUD_2 continues to carry the length there).

## Verification

- `canfd_lane_offsets` produces a contiguous terminated prefix at all reach values; idle frames byte-identical to stock.
- `opendbc/car/honda` + `opendbc/can` unit tests, `ruff`, `ty` all pass.

## If lanes still don't render

The next candidate from the same analysis: LANE_PATH/HUD_OBJECTS are currently TX'd on bus 0 only, while the other radar look-alikes (RADAR_LEAD, RADAR_LEAD2, 0x310, 0x1A45AA4E) go out on both bus 0 and 2, and `honda.h` notes the camera consumes them too. Mirroring the TX onto bus 2 is already allowed by the safety TX list.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4b52d00-68fd-4657-a523-bf1a301f0cb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4b52d00-68fd-4657-a523-bf1a301f0cb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

