### PR TITLE
CAN FD: pulse LKAS_STATE_CHANGE like the stock camera so the dash renders lane lines

### DIFF
--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -130,6 +130,8 @@ class CarController(CarControllerBase):
     self.hud_object_author = hud_objects.HudObjectAuthor()
     self.lane_path_fitter = lane_path.LanePathFitter()
     self.dash_lane = lane_path.DashLane([lane_path.OFFSET_UNAVAILABLE] * lane_path.NUM_PTS, 0.0, False, False)
+    self.lkas_hud_key = None
+    self.lkas_state_change_frames = 0
     self.tja_control = CP.carFingerprint in HONDA_BOSCH_TJA_CONTROL
     self.param_writer = HondaParamWriter()
 
@@ -389,8 +391,22 @@ class CarController(CarControllerBase):
       steering_available = CS.out.cruiseState.available and CS.out.vEgo > max(self.params.STEER_GLOBAL_MIN_SPEED, self.CP.minSteerSpeed)
       reduced_steering = CS.out.steeringPressed
       steer_maxed = abs(apply_torque) >= self.params.STEER_MAX
+
+      lkas_state_change = None
+      if self.CP.carFingerprint in HONDA_BOSCH_CANFD:
+        # The stock camera holds LKAS_STATE_CHANGE low and pulses it high for ~3s around HUD state
+        # changes; holding it high permanently (the default below) suppresses the dash lane lines.
+        hud_key = (bool(hud_control.lanesVisible) and not steer_maxed, bool(CC.latActive),
+                   bool(alert_steer_required), bool(CS.out.steerFaultPermanent))
+        if hud_key != self.lkas_hud_key:
+          self.lkas_hud_key = hud_key
+          self.lkas_state_change_frames = 30  # 3s at the 10Hz LKAS_HUD rate, matching stock pulse length
+        lkas_state_change = self.lkas_state_change_frames > 0
+        self.lkas_state_change_frames = max(0, self.lkas_state_change_frames - 1)
+
       can_sends.extend(hondacan.create_lkas_hud(self.packer, self.CAN.lkas, self.CP, hud_control, CC.latActive,
-                                                steering_available, reduced_steering, alert_steer_required, CS.lkas_hud, steer_maxed, CS))
+                                                steering_available, reduced_steering, alert_steer_required, CS.lkas_hud, steer_maxed, CS,
+                                                lkas_state_change=lkas_state_change))
 
       if self.CP.openpilotLongitudinalControl:
         # TODO: combining with create_acc_hud block above will change message order and will need replay logs regenerated

--- a/opendbc/car/honda/hondacan.py
+++ b/opendbc/car/honda/hondacan.py
@@ -178,7 +178,8 @@ def create_acc_hud(packer, bus, CP, enabled, pcm_speed, pcm_accel, hud_control, 
   return packer.make_can_msg("ACC_HUD", bus, acc_hud_values)
 
 
-def create_lkas_hud(packer, bus, CP, hud_control, lat_active, steering_available, reduced_steering, alert_steer_required, lkas_hud, steer_maxed, CS):
+def create_lkas_hud(packer, bus, CP, hud_control, lat_active, steering_available, reduced_steering, alert_steer_required, lkas_hud, steer_maxed, CS,
+                    lkas_state_change=None):
   commands = []
 
   lkas_hud_values = {
@@ -189,6 +190,11 @@ def create_lkas_hud(packer, bus, CP, hud_control, lat_active, steering_available
     'DASHED_LANES': lat_active,
     'BEEP': 0,
   }
+
+  # MDX CAN FD factory logs show the stock camera holds LKAS_STATE_CHANGE low, pulsing it high for ~3s
+  # only when the HUD state changes; holding it high permanently suppresses the dash lane-line rendering.
+  if lkas_state_change is not None:
+    lkas_hud_values['LKAS_STATE_CHANGE'] = int(lkas_state_change)
 
   if CP.carFingerprint in (HONDA_BOSCH_RADARLESS | HONDA_BOSCH_CANFD):
     lkas_hud_values['LANE_LINES'] = 3


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Lane lines still don't render on the MDX 2025 dash even after LANE_PATH was reshaped into the stock terminated-prefix form (#603). Verified from the test drive log `3792d010590cb83a/0000010a--0d74b800cf` that the terminated prefix went out correctly on-car, which isolated the remaining difference.

## Root cause

A full-payload diff of dash-visible bus 0 traffic between the factory-ACC-with-lanes drive (`3792d010590cb83a/00000107--49f1de4d88`) and the openpilot drive left exactly one non-ACC-state difference: a single bit in LKAS_HUD (0x33D).

- Factory lanes-on frames: `01440048180000`; openpilot: `41440048180000` — XOR is bit 6 of byte 0 = `LKAS_STATE_CHANGE`.
- The stock camera holds this bit **low** (600/600 frames in a lanes-on segment) and pulses it high for exactly 30 frames (~3s at the 10Hz LKAS_HUD rate); all 3 pulses in the factory log coincide with an LKAS_HUD payload change (±2 frames).
- openpilot hard-codes `LKAS_STATE_CHANGE: 1` on every frame (601/601 in the test drive). The dash appears to treat a permanent "state change in progress" as a reason to suppress the lane visualization.

## Fix

On CAN FD cars, hold `LKAS_STATE_CHANGE` low and pulse it high for 30 frames (3s at 10Hz, matching the stock pulse length) when the HUD state changes (lanesVisible/steer-maxed, latActive, steer-required alert, steer fault). With the bit low, openpilot's LKAS_HUD payload is now byte-identical to the factory lanes-on frames. Other Honda platforms keep the existing always-1 behavior.

## Verification

- `create_lkas_hud` with the pulse low/high produces `01440048180000` / `41440048180000` — matching the factory frames exactly.
- `opendbc/car/honda` unit tests, `ruff`, `ty` pass.

## Ruled out from the same logs

ACC_HUD deltas (engagement state only), 0x310 (engagement state only), 0x6CD5555 (byte-constant even with lanes displayed), RADAR_LEAD byte deltas (lead distance/target speed), mux sync and TX rate/bus/checksum (lead icon renders from the same stream). If lanes still don't render after this, the remaining candidate is mirroring LANE_PATH/HUD_OBJECTS onto bus 2 like the other radar look-alikes (the camera consumes them per `honda.h`, and the safety TX list already allows it).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4b52d00-68fd-4657-a523-bf1a301f0cb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4b52d00-68fd-4657-a523-bf1a301f0cb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

