### PR TITLE
CAN FD lane lines: RADAR_LEAD carries LANE_PATH length — keep it in lockstep with the authored path

### DIFF
--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -245,7 +245,10 @@ class CarController(CarControllerBase):
           self.radar_mux += 1
         # radar_msgs.extend(hondacan.create_canfd_50hz_radar_messages(self.packer, self.CAN.pt, self.radar_mux))
       if self.frame % 20 == 0:
-        radar_msgs.extend(hondacan.create_canfd_5hz_radar_messages(self.packer, self.CAN.pt, CS.radar_ref_counter))
+        # RADAR_LEAD's LANE_PATH_LENGTH must track the valid-point count of the LANE_PATH sweep we are
+        # authoring; the stock radar keeps the two in lockstep and the dash won't draw lanes otherwise.
+        radar_msgs.extend(hondacan.create_canfd_5hz_radar_messages(self.packer, self.CAN.pt, CS.radar_ref_counter,
+                                                                   lane_path.canfd_lane_length(self.dash_lane)))
 
       # mirror each packed frame onto both the powertrain bus and the camera bus
       for addr, dat, _ in radar_msgs:

--- a/opendbc/car/honda/hondacan.py
+++ b/opendbc/car/honda/hondacan.py
@@ -316,7 +316,7 @@ def create_canfd_50hz_radar_messages(packer, bus, radar_mux):
   return commands
 
 
-def create_canfd_5hz_radar_messages(packer, bus, radar_ref_cntr):
+def create_canfd_5hz_radar_messages(packer, bus, radar_ref_cntr, lane_path_length=6):
   commands = []
 
   radar_lead_values = {
@@ -324,7 +324,9 @@ def create_canfd_5hz_radar_messages(packer, bus, radar_ref_cntr):
     'SET_ME_X01': 0x01,
     # stock radar transmits a constant 140 here (confirmed from logs); 120 causes a camera mismatch
     'TARGET_SPEED_MAYBE': 140,
-    'LEAD_DISTANCE_MAYBE': 6,
+    # stock: number of valid points in the current LANE_PATH sweep (6 = idle). The dash cross-checks
+    # this against the path's in-band 2047 terminator; a mismatch suppresses the lane-line rendering.
+    'LANE_PATH_LENGTH': lane_path_length,
   }
   commands.append(packer.make_can_msg('RADAR_LEAD', bus, radar_lead_values))
 

--- a/opendbc/car/honda/lane_path.py
+++ b/opendbc/car/honda/lane_path.py
@@ -62,12 +62,20 @@ CANFD_MIN_VALID_PTS = 6
 CANFD_IDLE_OFFSETS = [0] * CANFD_MIN_VALID_PTS + [OFFSET_UNAVAILABLE] * (NUM_PTS - CANFD_MIN_VALID_PTS)
 
 
+def canfd_lane_length(dash_lane) -> int:
+  """Valid-point count of the stock-form path. The stock radar mirrors this in RADAR_LEAD's
+  LANE_PATH_LENGTH signal (6 when idle), which the dash cross-checks against the in-band terminator."""
+  if dash_lane.reach <= 0.0 or dash_lane.offsets[0] == OFFSET_UNAVAILABLE:
+    return CANFD_MIN_VALID_PTS
+  return max(CANFD_MIN_VALID_PTS, min(CANFD_MAX_VALID_PTS, round(dash_lane.reach * CANFD_MAX_VALID_PTS)))
+
+
 def canfd_lane_offsets(dash_lane) -> list[int]:
   """Reshape a DashLane's 40 offsets into the stock CAN FD radar form: a terminated valid prefix whose
   length scales with reach, or the stock idle pattern when there is nothing to draw."""
   if dash_lane.reach <= 0.0 or dash_lane.offsets[0] == OFFSET_UNAVAILABLE:
     return CANFD_IDLE_OFFSETS
-  n_valid = max(CANFD_MIN_VALID_PTS, min(CANFD_MAX_VALID_PTS, round(dash_lane.reach * CANFD_MAX_VALID_PTS)))
+  n_valid = canfd_lane_length(dash_lane)
   return list(dash_lane.offsets[:n_valid]) + [OFFSET_UNAVAILABLE] * (NUM_PTS - n_valid)
 
 

--- a/opendbc/dbc/generator/honda/honda_common_canfd.dbc
+++ b/opendbc/dbc/generator/honda/honda_common_canfd.dbc
@@ -49,7 +49,7 @@ BO_ 254913116 RADAR_LEAD: 8 XXX
  SG_ SET_ME_X01 : 5|1@0+ (1,0) [0|1] "" XXX
  SG_ CNTR_REF : 7|2@0+ (1,0) [0|3] "" XXX
  SG_ TARGET_SPEED_MAYBE : 15|8@0+ (1,0) [0|255] "" XXX
- SG_ LEAD_DISTANCE_MAYBE : 31|6@0+ (1,0) [0|63] "" XXX
+ SG_ LANE_PATH_LENGTH : 31|6@0+ (1,0) [0|63] "" XXX
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" XXX
 
@@ -61,3 +61,5 @@ BO_ 440773198 BOSCH_SUPPLEMENTAL_CANFD: 8 XXX
 
 BO_ 1808 RADAR_SUPP_TICK_REFERENCE: 32 XXX
  SG_ IGNORE : 11|1@0+ (1,0) [0|1] "" XXX
+
+CM_ SG_ 254913116 LANE_PATH_LENGTH "number of valid LANE_PATH points in the current sweep (6 = idle/no lane, up to 23-24); the dash needs this to match the in-band 2047 terminator to draw the lane lines";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Lane lines still don't render on the MDX 2025 dash after the LANE_PATH terminated-prefix fix and the LKAS_STATE_CHANGE pulse fix (test drive `3792d010590cb83a/0000010a--0d74b800cf`).

## Root cause (audit of the hardcoded radar spoof messages)

Signal-level diff of every spoofed radar message (RADAR_HUD_CANFD 0x310, RADAR_LEAD 0xF31AA5C, RADAR_LEAD2 0xF31AA52, BOSCH_SUPPLEMENTAL 0x1A45AA4E, ACC_HUD 0x30C) between the factory-lanes-on log (`3792d010590cb83a/00000107--49f1de4d88`) and the openpilot drive found the mismatch in RADAR_LEAD:

**The 6-bit field at bit 31 (previously `LEAD_DISTANCE_MAYBE`) is the LANE_PATH sweep length.** Correlating every factory RADAR_LEAD frame against the most recently completed LANE_PATH bank sweep: the field equals the sweep's valid-point count in **1100/1201 frames**, within ±1 for another 97 (transitions). It reads 6 when parked/no-lane (matching the 6-point idle path) and tracks 7..23 while driving with lanes displayed.

openpilot hardcodes 6 ("no lane") while now authoring a full 23-point path — the dash cross-checks the announced length against the path's in-band 2047 terminator, and on a mismatch draws nothing. This explains why the lead car renders (HUD_OBJECTS is independent) while lanes never do, regardless of LANE_PATH content.

Everything else in the spoof set checked out: RADAR_HUD_CANFD bits match factory in both engaged/disengaged states, BOSCH_SUPPLEMENTAL is byte-identical, RADAR_LEAD's TARGET_SPEED (140) is within the stock range (120-166, mode 136), and RADAR_LEAD2 / ACC_HUD deltas track lead distance and ACC state, not lanes.

## Fix

- Rename the signal to `LANE_PATH_LENGTH` in `honda_common_canfd.dbc` (with a comment documenting the finding).
- New `canfd_lane_length()` in `lane_path.py` shares the prefix-length computation with `canfd_lane_offsets()`, so the announced length and the in-band terminator can never disagree.
- `create_canfd_5hz_radar_messages` takes the length and the carcontroller feeds it from the current `dash_lane` (6 when blank, up to 23 at full reach).

## Verification

- Packed RADAR_LEAD byte 3 = `length << 2`: idle `0x18` and 22-point `0x58`, byte-matching factory parked and driving frames respectively.
- `canfd_lane_length` and `canfd_lane_offsets` agree at every reach value (blank: 6/6, full: 23/23).
- `opendbc/car/honda` + `opendbc/can` unit tests, `ruff`, `ty` pass; generated DBC regenerated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4b52d00-68fd-4657-a523-bf1a301f0cb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4b52d00-68fd-4657-a523-bf1a301f0cb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

