### PR TITLE
CAN FD: self-heal brake-module cruise fault latched during the radar-disable handoff

### DIFF
--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -132,6 +132,8 @@ class CarController(CarControllerBase):
     self.dash_lane = lane_path.DashLane([lane_path.OFFSET_UNAVAILABLE] * lane_path.NUM_PTS, 0.0, False, False)
     self.lkas_hud_key = None
     self.lkas_state_change_frames = 0
+    self.brake_fault_clear_attempts = 0
+    self.brake_fault_clear_frame = 0
     self.tja_control = CP.carFingerprint in HONDA_BOSCH_TJA_CONTROL
     self.param_writer = HondaParamWriter()
 
@@ -254,6 +256,17 @@ class CarController(CarControllerBase):
       for addr, dat, _ in radar_msgs:
         can_sends.append((addr, dat, self.CAN.pt))
         can_sends.append((addr, dat, self.CAN.camera))
+
+      # Self-heal a brake-module cruise fault latched during the radar-disable handoff: the module
+      # faults if ACC_CONTROL (0x1DF) goes silent >~120ms between the radar disable in CarInterface.init
+      # and panda's switch to car safety, and stays latched for the ignition cycle. Once our look-alike
+      # stream has been up for a few seconds (fault condition gone), clear its DTCs to reset the latch.
+      # Only at standstill while disengaged, retried a few times at 1s spacing.
+      if CS.brake_cruise_fault and self.frame >= 500 and self.brake_fault_clear_attempts < 5 and not CC.enabled \
+         and CS.out.vEgoRaw < 0.1 and (self.frame - self.brake_fault_clear_frame) >= 100:
+        can_sends.extend(hondacan.create_brake_fault_clear_msgs(self.CAN.pt))
+        self.brake_fault_clear_attempts += 1
+        self.brake_fault_clear_frame = self.frame
 
     # Send steering command.
     can_sends.append(hondacan.create_steering_control(self.packer, self.CAN, apply_torque, CC.latActive, self.tja_control))

--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -259,10 +259,11 @@ class CarController(CarControllerBase):
 
       # Self-heal a brake-module cruise fault latched during the radar-disable handoff: the module
       # faults if ACC_CONTROL (0x1DF) goes silent >~120ms between the radar disable in CarInterface.init
-      # and panda's switch to car safety, and stays latched for the ignition cycle. Once our look-alike
-      # stream has been up for a few seconds (fault condition gone), clear its DTCs to reset the latch.
-      # Only at standstill while disengaged, retried a few times at 1s spacing.
-      if CS.brake_cruise_fault and self.frame >= 500 and self.brake_fault_clear_attempts < 5 and not CC.enabled \
+      # and panda's switch to car safety, and stays latched for the ignition cycle. Carstate signals
+      # brake_fault_clear_pending while it holds cruiseState.available low waiting for the fault to
+      # clear; once our look-alike stream has been up for a few seconds (fault condition gone), clear
+      # the module's DTCs to reset the latch. Only at standstill while disengaged, retried at 1s spacing.
+      if CS.brake_fault_clear_pending and self.frame >= 500 and self.brake_fault_clear_attempts < 5 and not CC.enabled \
          and CS.out.vEgoRaw < 0.1 and (self.frame - self.brake_fault_clear_frame) >= 100:
         can_sends.extend(hondacan.create_brake_fault_clear_msgs(self.CAN.pt))
         self.brake_fault_clear_attempts += 1

--- a/opendbc/car/honda/carstate.py
+++ b/opendbc/car/honda/carstate.py
@@ -58,6 +58,7 @@ class CarState(CarStateBase):
     self.initial_accFault_cleared_timer = int(10 / DT_CTRL) # 10 seconds after startup for initial faults to clear
     self.radar_ref_counter = 0
     self.supp_tick = False
+    self.brake_cruise_fault = False
 
     # Only radarless cars have a camera that emits HUD_OBJECTS to poll for secondary vehicle locations.
     # On CAN FD cars the radar owned HUD_OBJECTS and it is disabled, so there is nothing to track.
@@ -141,6 +142,11 @@ class CarState(CarStateBase):
       # TODO: better handle delayed steering enablement on ALT_RADAR cars
       self.low_speed_alert = False
     ret.lowSpeedAlert = self.low_speed_alert
+
+    # Raw latched brake-module fault; the carcontroller uses this to self-heal a cruise fault
+    # latched during the radar-disable handoff (see create_brake_fault_clear_msgs).
+    if self.CP.carFingerprint in HONDA_BOSCH_CANFD:
+      self.brake_cruise_fault = bool(cp.vl["BRAKE_MODULE"]["CRUISE_FAULT"])
 
     # Log non-critical stock ACC/LKAS faults if Nidec (camera) or longitudinal CANFD alt-brake
     if self.CP.carFingerprint not in HONDA_BOSCH:

--- a/opendbc/car/honda/carstate.py
+++ b/opendbc/car/honda/carstate.py
@@ -58,7 +58,7 @@ class CarState(CarStateBase):
     self.initial_accFault_cleared_timer = int(10 / DT_CTRL) # 10 seconds after startup for initial faults to clear
     self.radar_ref_counter = 0
     self.supp_tick = False
-    self.brake_cruise_fault = False
+    self.brake_fault_clear_pending = False
 
     # Only radarless cars have a camera that emits HUD_OBJECTS to poll for secondary vehicle locations.
     # On CAN FD cars the radar owned HUD_OBJECTS and it is disabled, so there is nothing to track.
@@ -142,11 +142,6 @@ class CarState(CarStateBase):
       # TODO: better handle delayed steering enablement on ALT_RADAR cars
       self.low_speed_alert = False
     ret.lowSpeedAlert = self.low_speed_alert
-
-    # Raw latched brake-module fault; the carcontroller uses this to self-heal a cruise fault
-    # latched during the radar-disable handoff (see create_brake_fault_clear_msgs).
-    if self.CP.carFingerprint in HONDA_BOSCH_CANFD:
-      self.brake_cruise_fault = bool(cp.vl["BRAKE_MODULE"]["CRUISE_FAULT"])
 
     # Log non-critical stock ACC/LKAS faults if Nidec (camera) or longitudinal CANFD alt-brake
     if self.CP.carFingerprint not in HONDA_BOSCH:
@@ -233,11 +228,16 @@ class CarState(CarStateBase):
     ret.cruiseState.available = bool(cp.vl[self.car_state_scm_msg]["MAIN_ON"])
 
     # Bosch cars take a few minutes after startup to clear prior faults
+    self.brake_fault_clear_pending = False
     if ret.accFaulted:
       if (self.CP.carFingerprint in HONDA_BOSCH) and not self.initial_accFault_cleared:
         # block via cruiseState since accFaulted is not reversible until offroad
         ret.accFaulted = False
         ret.cruiseState.available = False
+        # CAN FD: the brake module latches CRUISE_FAULT if the radar-disable handoff left ACC_CONTROL
+        # silent too long, and never clears on its own. While in this wait-for-clear state, ask the
+        # carcontroller to actively clear the latch (UDS DTC clear) once its look-alike stream is up.
+        self.brake_fault_clear_pending = self.CP.carFingerprint in HONDA_BOSCH_CANFD
     elif self.initial_accFault_cleared_timer == 0:
       self.initial_accFault_cleared = True
 

--- a/opendbc/car/honda/hondacan.py
+++ b/opendbc/car/honda/hondacan.py
@@ -1,4 +1,4 @@
-from opendbc.car import CanBusBase
+from opendbc.car import CanBusBase, CanData, uds
 from opendbc.car.common.conversions import Conversions as CV
 from opendbc.car.honda.values import (HondaFlags, HONDA_BOSCH, HONDA_BOSCH_RADARLESS,
                                       HONDA_BOSCH_CANFD, CarControllerParams)
@@ -268,6 +268,22 @@ def create_canfd_supplemental(packer, bus):
     'SET_ME_X41': 0x41,
   }
   return packer.make_can_msg("BOSCH_SUPPLEMENTAL_CANFD", bus, values)
+
+
+# Brake module (VSA) UDS address; response address is 0x18DAF128
+BRAKE_MODULE_DIAG_ADDR = 0x18DA28F1
+
+
+def create_brake_fault_clear_msgs(bus):
+  """UDS extended-diagnostic session + ClearDiagnosticInformation (all DTC groups) to the brake module.
+
+  If the radar's 50Hz ACC_CONTROL stream goes silent for more than ~120ms during the radar-disable
+  handoff, the brake module latches CRUISE_FAULT for the rest of the ignition cycle. Once openpilot's
+  radar look-alike stream is up (so the fault condition is gone), clearing DTCs resets the latch.
+  Fire-and-forget single frames; the carcontroller checks BRAKE_MODULE.CRUISE_FAULT for success."""
+  ext_diag = bytes([0x02, uds.SERVICE_TYPE.DIAGNOSTIC_SESSION_CONTROL, uds.SESSION_TYPE.EXTENDED_DIAGNOSTIC, 0, 0, 0, 0, 0])
+  clear_dtc = bytes([0x04, uds.SERVICE_TYPE.CLEAR_DIAGNOSTIC_INFORMATION, 0xFF, 0xFF, 0xFF, 0, 0, 0])
+  return [CanData(BRAKE_MODULE_DIAG_ADDR, ext_diag, bus), CanData(BRAKE_MODULE_DIAG_ADDR, clear_dtc, bus)]
 
 
 # Radar MUX banks: 1-10, 17-26, 33-42, 49-58. Each bank is a fresh sweep of path points.

--- a/opendbc/safety/modes/honda.h
+++ b/opendbc/safety/modes/honda.h
@@ -282,6 +282,16 @@ static bool honda_tx_hook(const CANPacket_t *msg) {
     }
   }
 
+  // Only extended-diag session ("\x02\x10\x03") and clear-DTC ("\x04\x14\xFF\xFF\xFF") allowed on the
+  // brake module diagnostics address, used to clear a cruise fault latched during the radar-disable handoff
+  if (msg->addr == 0x18DA28F1U) {
+    const bool ext_diag_session = (GET_BYTES(msg, 0, 4) == 0x00031002U) && (GET_BYTES(msg, 4, 4) == 0x0U);
+    const bool clear_dtc = (GET_BYTES(msg, 0, 4) == 0xFFFF1404U) && (GET_BYTES(msg, 4, 4) == 0x000000FFU);
+    if (!ext_diag_session && !clear_dtc) {
+      tx = false;
+    }
+  }
+
   return tx;
 }
 
@@ -356,6 +366,7 @@ static safety_config honda_bosch_init(uint16_t param) {
   // forwarded across the open relay, so each is sent on both buses; the control messages stay on bus 0.
   static CanMsg HONDA_CANFD_LONG_TX_MSGS[] = {{0xE4, 0, 5, .check_relay = true}, {0x1DF, 0, 8, .check_relay = true}, {0x1EF, 0, 8, .check_relay = false},
                                               {0x30C, 0, 8, .check_relay = false}, {0x33D, 0, 8, .check_relay = true}, {0x18DAB0F1, 0, 8, .check_relay = false},
+                                              {0x18DA28F1, 0, 8, .check_relay = false},
                                               {0x310, 0, 8, .check_relay = false}, {0x6CD5558, 0, 8, .check_relay = true}, {0x6CD5559, 0, 8, .check_relay = false},
                                               {0xF31AA52, 0, 8, .check_relay = false}, {0xF31AA5C, 0, 8, .check_relay = true}, {0x1A45AA4E, 0, 8, .check_relay = false},
                                               {0x310, 2, 8, .check_relay = false}, {0x6CD5558, 2, 8, .check_relay = true}, {0x6CD5559, 2, 8, .check_relay = false},

--- a/opendbc/safety/tests/test_honda.py
+++ b/opendbc/safety/tests/test_honda.py
@@ -624,7 +624,7 @@ class TestHondaBoschCANFDLongSafety(TestHondaBoschLongSafety, TestHondaBoschCANF
   STEER_BUS = 0
   BUTTONS_BUS = 0
 
-  TX_MSGS = [[0xE4, 0], [0x1DF, 0],  [0x1EF, 0], [0x30C, 0], [0x33D, 0], [0x18DAB0F1, 0], [0x310, 0], [0x310, 2]]
+  TX_MSGS = [[0xE4, 0], [0x1DF, 0],  [0x1EF, 0], [0x30C, 0], [0x33D, 0], [0x18DAB0F1, 0], [0x18DA28F1, 0], [0x310, 0], [0x310, 2]]
   FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0x1DF, 0x33D]}
   RELAY_MALFUNCTION_ADDRS = {0: (0xE4, 0x1DF, 0x33D)}  # STEERING_CONTROL / ACC_CONTROL / LKAS_HUD
 
@@ -632,6 +632,21 @@ class TestHondaBoschCANFDLongSafety(TestHondaBoschLongSafety, TestHondaBoschCANF
     super().setUp()
     self.safety.set_safety_hooks(CarParams.SafetyModel.hondaBosch, HondaSafetyFlags.BOSCH_CANFD | HondaSafetyFlags.BOSCH_LONG)
     self.safety.init_tests()
+
+  def test_brake_module_diagnostics(self):
+    # only the extended-diag session and clear-DTC frames are allowed on the brake module diag address
+    ext_diag = libsafety_py.make_CANPacket(0x18DA28F1, self.PT_BUS, b"\x02\x10\x03\x00\x00\x00\x00\x00")
+    self.assertTrue(self._tx(ext_diag))
+
+    clear_dtc = libsafety_py.make_CANPacket(0x18DA28F1, self.PT_BUS, b"\x04\x14\xff\xff\xff\x00\x00\x00")
+    self.assertTrue(self._tx(clear_dtc))
+
+    for bad in (b"\x02\x3e\x80\x00\x00\x00\x00\x00",   # tester present
+                b"\x02\x10\x01\x00\x00\x00\x00\x00",   # default session
+                b"\x04\x14\xff\xff\xff\x00\x00\x01",   # trailing garbage
+                b"\x02\x11\x01\x00\x00\x00\x00\x00"):  # ECU reset
+      msg = libsafety_py.make_CANPacket(0x18DA28F1, self.PT_BUS, bad)
+      self.assertFalse(self._tx(msg), bad)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Drives on the MDX 2025 latch a brake-module `CRUISE_FAULT` (0x1BE) ~8s in, killing ACC for the whole ignition cycle (routes `0000010e`, `0000010f`).

Timeline analysis across five drives shows the cause is a startup race, not message content: `CarInterface.init` silences the radar via UDS communication-control, but `card.py` only sets `ControlsReady` afterwards, so pandad's panda safety switch (elm327 → hondaBosch) lags and every look-alike frame is blocked in between. The radar's 50Hz ACC_CONTROL (0x1DF) stream goes dark for the duration of that switch:

| drive | gap (radar-off → first openpilot 0x1DF) | brake fault |
|---|---|---|
| 000000f9 | 63 ms | none |
| 0000010a | 74 ms | none |
| 00000101 | 93 ms | none |
| 0000010e | 124 ms | latched |
| 0000010f | 154 ms | latched (fault at 8.137s preceded openpilot's first wire frame at 8.146s) |

The brake module tolerates ~5-6 missed 0x1DF cycles (~120 ms) before latching until ignition off. It never self-clears (verified: fault persisted for a full 7-minute drive with the look-alike stream healthy).

## Fix (opendbc-resident self-heal)

The trigger is tied to carstate's existing wait-for-clear state — the "block via cruiseState since accFaulted is not reversible until offroad" branch, which is entered every frame exactly while the latched fault persists during the startup window:

- Carstate raises `brake_fault_clear_pending` in that branch (CAN FD only). A fault appearing after `initial_accFault_cleared` latches is treated as a real fault and never auto-cleared.
- The carcontroller, once its radar look-alike stream has been up ≥5s (fault condition gone), sends `create_brake_fault_clear_msgs()`: UDS extended-diag session (`02 10 03`) + ClearDiagnosticInformation all groups (`04 14 FF FF FF`) to the brake module (0x18DA28F1), fire-and-forget. Only at standstill while disengaged, retried at 1s spacing, max 5 attempts; stops as soon as the fault bit drops (carstate lowers the pending flag).
- Safety: 0x18DA28F1 added to `HONDA_CANFD_LONG_TX_MSGS` with a strict content filter allowing exactly those two frames (mirroring the tester-present filter on 0x18DAB0F1); new `test_brake_module_diagnostics` covers allowed/rejected payloads.

Note: an init-time "disable → wait → clear" sequence would not work — the 0x1DF silence continues after `init` returns (the safety switch only happens then), so the module would just re-latch. The clear must come after the look-alike stream is flowing, hence the carcontroller.

## Prevention (openpilot fork, separate change)

The race itself is best removed in `card.py` by setting `ControlsReady` *before* `CI.init(...)`, so pandad's safety switch overlaps the UDS handshake and the look-alikes take over the moment the radar goes silent. This PR makes the system recover even when the race is lost.

## Verification

- State machine simulated end-to-end: pending only while the masked-fault state is active, drops when the fault clears, and a post-window fault surfaces as real `accFaulted` with no clear attempted.
- All 345 Honda safety tests pass (including the new diagnostics test); Toyota cross-mode safety tests pass (foreign-mode TX of the new address stays blocked).
- `ruff`, `ty`, and Honda unit tests pass.
- Packed UDS frames verified: `0x18DA28F1: 0210030000000000` and `0414ffffff000000`.

## Open question for the car test

Whether the VSA resets the latched CRUISE_FAULT status on a DTC clear (vs. requiring an ignition cycle) is the one thing only the car can confirm. If it refuses in the default session, the extended-session frame preceding the clear should cover it.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4b52d00-68fd-4657-a523-bf1a301f0cb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4b52d00-68fd-4657-a523-bf1a301f0cb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

