### PR TITLE
Honda Nidec: improve accel tracking (PCM_SPEED lead, smooth PCM_GAS, SET_ME_X01)

### DIFF
--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -156,7 +156,10 @@ class CarController(CarControllerBase):
     self.nidec_pid = PIDController(k_p=([0,], [0,]),
                                    k_i=([0., 5., 35.], [1.2, 0.8, 0.5]),
                                    k_f=1,
-                                   pos_limit=0., # self.params.NIDEC_ACCEL_MAX,
+                                   # pos_limit=0 made feedback subtract-only: with chronic undershoot the
+                                   # integral pins at/below zero and drags the command further down
+                                   # (route 162: mean correction -0.11 while cmd > 0.2, worst -0.94)
+                                   pos_limit=1.0,
                                    neg_limit=self.params.NIDEC_ACCEL_MIN)
     self.nidec_pid.reset()
 

--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -241,6 +241,12 @@ class CarController(CarControllerBase):
           self.windfactor_before_gasmax = self.windfactor
 
       else:
+        # the integrator is frozen at standstill; unwind a stale negative integral when
+        # the planner commands positive accel, otherwise it cancels the resume command
+        # (logs show it stuck at -0.2..-0.5 m/s2 for the first 1-2s of every pull-away)
+        if (CS.out.vEgo <= 1e-5) and (actuators.accel > 0) and (self.nidec_pid.i < 0):
+          self.nidec_pid.i *= 1.0 - 2.0 * DT_CTRL  # ~0.5s time constant
+          self.nidec_pid_factor = float(self.nidec_pid.i)
         self.accel = actuators.accel + self.nidec_pid_factor
         adjust_accel = self.accel + hill_brake
 

--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -311,10 +311,10 @@ class CarController(CarControllerBase):
       pcm_accel = int(0.0)
     else:
       # The PCM acts as a speed servo: with PCM_GAS saturated, measured accel scales with
-      # (PCM_SPEED - vEgo) at roughly 0.25 (m/s^2) per m/s of speed lead, saturating around
-      # +2.5 m/s of lead. Lead the setpoint by ~4s of PID-corrected accel so the servo
-      # carries the commanded accel, and cap the lead where the response saturates.
-      speed_lead = float(np.clip(4.0 * adjust_accel, -8.0, 2.5))
+      # (PCM_SPEED - vEgo) at roughly 0.25 (m/s^2) per m/s of speed lead, so ~4s of lead
+      # yields the commanded accel (stock uses up to +8 m/s during resume/override ramps).
+      # Lead the setpoint with PID-corrected accel; cap at +6 m/s (covers NIDEC_ACCEL_MAX).
+      speed_lead = float(np.clip(4.0 * adjust_accel, -8.0, 6.0))
       pcm_speed = float(np.clip(CS.out.vEgo + speed_lead, 0.0, 100.0))
       pcm_accel = int(np.clip((self.gas_alpha + adjust_accel * self.gasfactor / 1.44) / max_accel, 0.0, 1.0) * self.params.NIDEC_GAS_MAX)
 

--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -321,10 +321,13 @@ class CarController(CarControllerBase):
       pcm_accel = int(0.0)
     else:
       # The PCM acts as a speed servo: with PCM_GAS saturated, measured accel scales with
-      # (PCM_SPEED - vEgo) at roughly 0.25 (m/s^2) per m/s of speed lead, so ~4s of lead
-      # yields the commanded accel (stock uses up to +8 m/s during resume/override ramps).
+      # (PCM_SPEED - vEgo) at ~0.4-0.5 (m/s^2) per m/s of speed lead, saturating ~+0.9 m/s^2.
       # Lead the setpoint with PID-corrected accel; cap at +6 m/s (covers NIDEC_ACCEL_MAX).
-      speed_lead = float(np.clip(4.0 * adjust_accel, -8.0, 6.0))
+      # No hill term here: the servo rejects grade internally (residual grade pass-through
+      # only -0.07..+0.17 across routes without compensation), and hill-in-dv on route 162
+      # double-compensated (wasted dv uphill, starved dv downhill, err +0.32). Grade
+      # compensation lives on the gas channel, where it raises the servo's authority ceiling.
+      speed_lead = float(np.clip(4.0 * self.accel, -8.0, 6.0))
       pcm_speed = float(np.clip(CS.out.vEgo + speed_lead, 0.0, 100.0))
       # road load (aero + rolling) belongs on the gas channel, like Bosch's gas_pedal_force:
       # without it the gasfactor learner covers the load by inflating gain until gas saturates.

--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -171,6 +171,7 @@ class CarController(CarControllerBase):
     self.brake_pid.i = self.brake_pid_factor_non_lowspeed
 
     self.prior_gas_average = 0.0
+    self.pcm_gas_sent = 0
     self.average_factor = 0.95 if (Params().get("HondaFeedForwardParams") is None) else Params().get("HondaFeedForwardParams")
     self.creep_factor = 1.0 if (Params().get("HondaCreepFactorParams") is None) else Params().get("HondaCreepFactorParams")
     self.gas_alpha = 0.0 if (Params().get("HondaGasAlphaParams") is None) else Params().get("HondaGasAlphaParams")
@@ -325,9 +326,9 @@ class CarController(CarControllerBase):
       pcm_accel = int(np.clip((self.gas_alpha + adjust_accel * self.gasfactor / 1.44) / max_accel, 0.0, 1.0) * self.params.NIDEC_GAS_MAX)
 
     # feedforward for Nidec decaying-average gas pedal
-    # stock camera slews PCM_GAS at up to ~560 units/s; 20/frame (200/s) added up to
-    # 1s of ramp delay on large steps
-    max_increase = 60
+    # NOTE: this clip runs at 100Hz but ACC_HUD is sent at 10Hz, so up to ~200 units can
+    # still pass between sent frames; the real slew limit is applied at the send point
+    max_increase = 20
     prior_accel = int(self.new_accel)
     self.new_accel = int((pcm_accel - self.prior_gas_average * (1 - self.average_factor)) / self.average_factor)
     self.new_accel = int(np.clip(self.new_accel, 0, min(prior_accel + max_increase, self.params.NIDEC_GAS_MAX)))
@@ -459,7 +460,16 @@ class CarController(CarControllerBase):
 
       if self.CP.openpilotLongitudinalControl:
         # On Nidec, this also controls longitudinal positive acceleration
-        can_sends.append(hondacan.create_acc_hud(self.packer, self.CAN.pt, self.CP, CC.enabled, pcm_speed, self.new_accel,
+        send_gas = int(self.new_accel)
+        if self.CP.carFingerprint not in HONDA_BOSCH:
+          # limit rise of the transmitted PCM_GAS to stock's observed envelope: stock moves
+          # <=7/frame p90 while engaged but jumps +74/frame at launch and up to +114 during
+          # ramps. Falls are left unlimited (stock drops up to -100/frame, and the brake
+          # path zeroes new_accel immediately)
+          if not CS.out.gasPressed:  # gasPressed forces 198 to prevent a PCM fault; don't slew that
+            send_gas = min(send_gas, self.pcm_gas_sent + 60)
+          self.pcm_gas_sent = send_gas
+        can_sends.append(hondacan.create_acc_hud(self.packer, self.CAN.pt, self.CP, CC.enabled, pcm_speed, send_gas,
                                                  hud_control, hud_v_cruise, CS.is_metric, CS.acc_hud))
 
       steering_available = CS.out.cruiseState.available and CS.out.vEgo > max(self.params.STEER_GLOBAL_MIN_SPEED, self.CP.minSteerSpeed)

--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -310,11 +310,18 @@ class CarController(CarControllerBase):
       pcm_speed = 0.0
       pcm_accel = int(0.0)
     else:
-      pcm_speed = float(np.clip(CS.out.vEgo + 2 * actuators.accel, 0.0, 100.0))
+      # The PCM acts as a speed servo: with PCM_GAS saturated, measured accel scales with
+      # (PCM_SPEED - vEgo) at roughly 0.25 (m/s^2) per m/s of speed lead, saturating around
+      # +2.5 m/s of lead. Lead the setpoint by ~4s of PID-corrected accel so the servo
+      # carries the commanded accel, and cap the lead where the response saturates.
+      speed_lead = float(np.clip(4.0 * adjust_accel, -8.0, 2.5))
+      pcm_speed = float(np.clip(CS.out.vEgo + speed_lead, 0.0, 100.0))
       pcm_accel = int(np.clip((self.gas_alpha + adjust_accel * self.gasfactor / 1.44) / max_accel, 0.0, 1.0) * self.params.NIDEC_GAS_MAX)
 
     # feedforward for Nidec decaying-average gas pedal
-    max_increase = 20
+    # stock camera slews PCM_GAS at up to ~560 units/s; 20/frame (200/s) added up to
+    # 1s of ramp delay on large steps
+    max_increase = 60
     prior_accel = int(self.new_accel)
     self.new_accel = int((pcm_accel - self.prior_gas_average * (1 - self.average_factor)) / self.average_factor)
     self.new_accel = int(np.clip(self.new_accel, 0, min(prior_accel + max_increase, self.params.NIDEC_GAS_MAX)))
@@ -326,12 +333,14 @@ class CarController(CarControllerBase):
          (self.apply_brake_last == 0):
       gasfactor_error = (self.accel - CS.out.aEgo)
       self.gas_alpha = np.clip(self.gas_alpha + 0.0001 * gasfactor_error / 4.8, -3.0, 3.0)
-      self.gasfactor *= (1 + 0.0001 * gasfactor_error * adjust_accel)
+      # keep the learner from saturating pcm_gas into a 0/198 square wave: the PCM
+      # low-passes PCM_GAS (~1.4s), so bang-bang commands add over a second of gas lag
+      self.gasfactor = float(np.clip(self.gasfactor * (1 + 0.0001 * gasfactor_error * adjust_accel), 0.1, 1.5))
       more_new_accel_needed = (self.new_accel > pcm_accel and self.accel > CS.out.aEgo) or \
                               (self.new_accel < pcm_accel and self.accel < CS.out.aEgo)
       new_accel_factor = abs(gasfactor_error * (self.new_accel - pcm_accel))
       if more_new_accel_needed:
-        self.average_factor /= (1 + 0.0001 * new_accel_factor)
+        self.average_factor = max(0.5, self.average_factor / (1 + 0.0001 * new_accel_factor))
       else:
         self.average_factor = min(1.0, self.average_factor * (1 + 0.0001 * new_accel_factor))
 

--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -326,7 +326,11 @@ class CarController(CarControllerBase):
       # Lead the setpoint with PID-corrected accel; cap at +6 m/s (covers NIDEC_ACCEL_MAX).
       speed_lead = float(np.clip(4.0 * adjust_accel, -8.0, 6.0))
       pcm_speed = float(np.clip(CS.out.vEgo + speed_lead, 0.0, 100.0))
-      pcm_accel = int(np.clip((self.gas_alpha + adjust_accel * self.gasfactor / 1.44) / max_accel, 0.0, 1.0) * self.params.NIDEC_GAS_MAX)
+      # road load (aero + rolling) belongs on the gas channel, like Bosch's gas_pedal_force:
+      # without it the gasfactor learner covers the load by inflating gain until gas saturates.
+      # Stock holds mid-range gas (~100-130) at steady cruise, consistent with a load term.
+      gas_accel = adjust_accel + wind_brake_ms2 * self.windfactor
+      pcm_accel = int(np.clip((self.gas_alpha + gas_accel * self.gasfactor / 1.44) / max_accel, 0.0, 1.0) * self.params.NIDEC_GAS_MAX)
 
     # feedforward for Nidec decaying-average gas pedal
     # NOTE: this clip runs at 100Hz but ACC_HUD is sent at 10Hz, so up to ~200 units can

--- a/opendbc/car/honda/hondacan.py
+++ b/opendbc/car/honda/hondacan.py
@@ -164,7 +164,11 @@ def create_acc_hud(packer, bus, CP, enabled, pcm_speed, pcm_accel, hud_control, 
     acc_hud_values['ACC_ON'] = int(enabled)
     acc_hud_values['PCM_SPEED'] = pcm_speed * CV.MS_TO_KPH
     acc_hud_values['PCM_GAS'] = pcm_accel
-    acc_hud_values['SET_ME_X01'] = 1 if (pcm_accel == 0 or pcm_accel == 198) else 0
+    # stock camera raises this bit while the ACC speed servo is ramping to the set speed
+    # (resume, gas override, accelerating with no lead). With bang-bang gas the old
+    # (pcm_accel == 0 or 198) condition was 1 on ~99% of frames; keep it high whenever
+    # engaged so smoother gas commands don't flip the PCM out of speed-servo mode.
+    acc_hud_values['SET_ME_X01'] = 1 if enabled else 0
     acc_hud_values['FCM_OFF'] = acc_hud['FCM_OFF']
     acc_hud_values['FCM_OFF_2'] = acc_hud['FCM_OFF_2']
     acc_hud_values['FCM_PROBLEM'] = acc_hud['FCM_PROBLEM']


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On the ACURA_MDX_3G, measured accel lags `actuators.accel` badly: in route `3792d010590cb83a/00000160--865ab37329` the median latency from "command > 0.2 m/s²" to "aEgo > 0.2 m/s²" was **1.5 s (p90 3.5 s)**, with a chronic undershoot of **+0.18 m/s² mean tracking error** (RMS 0.40) while engaged. Stop-and-go routes (`.../0000015c` qlogs, `.../0000015d` rlogs) additionally show **1.5–2.3 s** resume-from-stop latency. Route `.../00000162` (user's speedfactor build) confirms the undershoot persists (+0.26 mean error while cmd > 0.2) and isolates the feedback-path cause (finding 7).

## What the logs show

Comparing the stock-camera route (`.../00000153--5916faf6fa`, no-output mode) against the active-control routes:

1. **The PCM is a speed servo — `PCM_SPEED` is the dominant lever.** With `PCM_GAS` pinned at 198 (91% of frames while commanding accel > 0.3), the pedal the PCM actually applied (`CAR_GAS`, 0x130) and the resulting accel scaled with `PCM_SPEED − vEgo`. Pooled system-ID across routes 160/15d/162 (controlling for grade and gas): **dv gain ≈ 0.39–0.46 m/s² per m/s at 35–65 kph**, **saturating at ~+0.9 m/s² beyond dv ≈ +2.5 m/s**. `pcm_speed = vEgo + 2*accel` therefore delivered roughly half the commanded accel even at full gas.

2. **Sent `PCM_GAS` was bang-bang** (65% of frames at 0, 35% at 198): `gasfactor` had learned to 2.81, saturating the raw command, and the decaying-average feedforward amplified it into a square wave. The PCM low-passes this (`PCM_GAS`→`CAR_GAS` lag **1.4 s**), whereas the stock camera's smooth signal is applied at ~0.1 s (`CAR_GAS ≈ 0.32·PCM_GAS`). At steady cruise stock holds mid-range gas (median 96–129 across 20–65 kph) with dv ≈ 0 — **gas carries the operating point / road load, speed lead carries the accel demand**.

3. **The `max_increase = 20` clip was not limiting the wire** (100 Hz clip vs 10 Hz send; measured median rising sent step 118). Stock movement (excluding 0/54/98/198 hold constants): p90 ≤ 7/frame engaged, +74/frame at launch, up to +114/frame in ramps.

4. **`SET_ME_X01`** was `1 if (pcm_accel == 0 or pcm_accel == 198)` — true on 99.4% of frames only because gas was bang-bang. Stock uses it as the accelerate-to-set-speed ramp flag.

5. **Standstill resumes were sabotaged by a frozen negative integral — it even held the brake on** 1.6–2.0 s after the positive command (route 15d).

6. Tracking error is 4.5× worse when the hybrid's engine is off (rpm < 300) — engine-restart lag out of EV mode (no code change).

7. **The accel PID was subtract-only (`pos_limit=0`)**: on route 162 the PID never exceeded 0.000 all route, averaged −0.11 while cmd > 0.2, leaving `adjust_accel` 0.30 m/s² below the planner request; worst case integral −0.94 vs cmd +1.04.

8. **The speed-channel zero-accel offset is not drag-shaped** (−0.18/+0.46/+0.16 m/s across speed bands — non-monotonic, 3–7× larger than aero at mid speeds): PCM servo characteristic, not physics.

9. **The PCM servo rejects grade internally.** Routes 160/15d (no hill compensation in the speed channel) show near-zero grade pass-through at fixed dv (residual slope −0.07 / +0.17, vs −1.0 for no internal compensation). Route 162 (hill included in the speed lead) shows the double-compensation signature: uphill dv absorbed by the servo (residual −0.25 at +0.35..0.8 m/s² grade), downhill dv starved (residual +0.31, and the worst tracking error of any route, +0.32 downhill). Its apparently perfect uphill error (+0.008) is an artifact of chronic global undershoot being offset by grade-proportional extra dv.

## Changes

- `pcm_speed`: lead with **4 s of PID-corrected accel, without the hill term** (`self.accel`; was 2 s of raw `actuators.accel`, briefly `adjust_accel` with hill), capped at **+6 m/s**. Grade compensation deliberately excluded from the speed channel (finding 9).
- **Road load and grade live on the gas channel**: gas input = `adjust_accel + wind_brake_ms2 · windfactor` (`adjust_accel` includes `hill_brake`), mirroring Bosch's `gas_pedal_force` — raises the servo's authority ceiling uphill/at speed. Without this term the `gasfactor` learner covered load by inflating gain until gas saturated.
- Clip the Nidec `gasfactor` learner to **[0.1, 1.5]**, floor `average_factor` at **0.5** (kills the 0/198 square wave).
- **`PCM_GAS` slew limit at the send point**: transmitted rise ≤ **+60 per 10 Hz frame** (stock envelope); falls unlimited; `gasPressed` bypasses.
- `SET_ME_X01`: send **while enabled**, decoupled from the gas value.
- **Unwind the stale negative integral at standstill resume** (~0.5 s time constant).
- **Allow positive PID correction**: `pos_limit` 0 → **+1.0 m/s²**.

## Validation

- **Safety tests pass** after every commit: `pytest opendbc/safety/tests/test_honda.py` → 296 passed, 251 skipped.
- **Offline replay** of the new gas chain against route 160: sent `PCM_GAS` goes from 64% at 0 / 34% at 198 to a median of 76 with 6% saturated.
- Packing smoke test of `create_acc_hud` on `acura_mdx_3g_can_generated`; `ruff` clean except one pre-existing warning.
- Full import of `carcontroller.py` requires the openpilot runtime; behavior must be confirmed on-car.

## Corrections to earlier revisions of this PR

- This hybrid brakes via `COMPUTER_BRAKE_HYBRID` (bits 55|10 of 0x1FA); earlier "no brake commands" claim was wrong. No gas>190 + brake>0 overlap.
- "`max_increase = 20` added up to 1 s of ramp delay" was wrong (finding 3); superseded by the send-point limiter.
- dv gain first reported ~0.25/m/s; pooled fit with controls: **0.39–0.46/m/s**, saturating ~+0.9 m/s².
- Commits 1–7 briefly had `hill_brake` inside the speed lead; removed in the final commit per finding 9.

## What to check on the next drive log

- Sent `PCM_GAS`: intermediate values, rises ≤ 60/frame, steady-cruise gas near stock's ~100–130 band.
- `nidec_pid_factor` (`actuatorsOutput.speed`) goes positive during undershoot; if it hunts, reduce `pos_limit` toward ~0.5.
- Onset latency well under 1 s (engine on); resume brake release ~0.5 s after positive command.
- Tracking error should now be symmetric uphill vs downhill (route 162 was +0.008 up / +0.32 down with hill-in-dv).
- Learners re-settle in the first minutes; `windfactor` now has a real job on the gas channel.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c74be460-595f-4f5c-8323-ef2fe75d1adb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c74be460-595f-4f5c-8323-ef2fe75d1adb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

