### PR TITLE
Honda: fix gas/wind-factor attr name mismatch that crashed card on CAN-FD long

### DIFF
--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -150,9 +150,9 @@ class CarController(CarControllerBase):
     self.bosch_last_gas = 0
 
     self.gasfactor = 1.0 if (Params().get("HondaGasFactorParams") is None) else Params().get("HondaGasFactorParams")
-    self.gasfactor_before_maxgas = self.gasfactor
+    self.gasfactor_before_gasmax = self.gasfactor
     self.windfactor = 1.0 if (Params().get("HondaWindFactorParams") is None) else Params().get("HondaWindFactorParams")
-    self.windfactor_before_maxgas = self.windfactor_before_brake = self.windfactor
+    self.windfactor_before_gasmax = self.windfactor_before_brake = self.windfactor
     self.pitch = 0.0
     self.radar_mux = 0
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
On the on-car route `ad9840558640c31d/0000002b--794500940f` (ACURA_MDX_4G_MMR, CAN-FD long), the `card` process crashed:

```
File "opendbc/car/honda/carcontroller.py", line 350, in update
    self.gasfactor = min(self.gasfactor, self.gasfactor_before_gasmax)
AttributeError: 'CarController' object has no attribute 'gasfactor_before_gasmax'.
             Did you mean: 'gasfactor_before_maxgas'?
```

The crash killed the car process, cascading into `relayMalfunction` / `commIssue` / `processNotRunning`.

## Root cause
The Bosch gas/wind-factor learning state is **initialized** in `__init__` as `gasfactor_before_maxgas` / `windfactor_before_maxgas`, but **read and written** in `update()` as `gasfactor_before_gasmax` / `windfactor_before_gasmax`. The read side (`min(..., self.gasfactor_before_gasmax)`) runs in the `gas_pedal_force >= BOSCH_ACCEL_MAX` branch, whose counterpart assignment only happens in the `else` branch. So the first time accel hits the max before the else branch has run, the attribute doesn't exist and it throws.

## Fix
Renamed the two `__init__` attributes to `..._before_gasmax` so they match the names used in `update()` and are always defined. (`windfactor_before_brake` is unchanged.)

Impacts all Honda Bosch longitudinal, including CAN-FD long. Pre-existing bug (not from the radar-timer work), but it prevents CAN-FD drives from running, so fixing here.

## Validation
- `opendbc/car/honda/carcontroller.py` compiles.
- Attribute names are now consistent (`_before_gasmax`) across init and usage.

## Files
- `opendbc/car/honda/carcontroller.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abdab9b7-d2a9-4086-bec8-0932b9052a41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abdab9b7-d2a9-4086-bec8-0932b9052a41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

