### PR TITLE
Honda CAN FD: fix dash lane lines suppressed by LKAS_STATE_CHANGE re-triggering

### DIFF
--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -231,6 +231,10 @@ class CarController(CarControllerBase):
         radar_msgs.append(hondacan.create_canfd_supplemental(self.packer, self.CAN.pt))
       if CS.radar_50hz_tick:
         # Cycle the radar MUX through the same banks the stock radar uses: 1-10, 17-26, 33-42, 49-58.
+        # This counter also drives the LANE_PATH/HUD_OBJECTS mux below: it advances exactly one step
+        # per transmitted frame, so the sweep stays contiguous even when a tick is missed (deriving
+        # the mux from the frame counter skipped a mux on every missed tick, leaving holes in the
+        # sweep the stock radar never produces).
         # These must be elif (not sequential if): a bare `if` that sets the bank start would fall
         # through to the `else` increment, skipping the bank-start values (17, 33, 49).
         if self.radar_mux >= 58:
@@ -406,8 +410,13 @@ class CarController(CarControllerBase):
       if self.CP.carFingerprint in HONDA_BOSCH_CANFD:
         # The stock camera holds LKAS_STATE_CHANGE low and pulses it high for ~3s around HUD state
         # changes; holding it high permanently (the default below) suppresses the dash lane lines.
-        hud_key = (bool(hud_control.lanesVisible) and not steer_maxed, bool(CC.latActive),
-                   bool(alert_steer_required), bool(CS.out.steerFaultPermanent))
+        # The key must contain exactly the signals that change the LKAS_HUD payload, nothing more:
+        # steer_maxed used to be in here (via SOLID_LANES) and its 10Hz flicker during city-speed
+        # steering re-triggered the pulse continuously, keeping LKAS_STATE_CHANGE high whenever a
+        # real lane path was being sent - which suppressed the dash lane lines entirely.
+        # (latActive isn't in the key: DASHED_LANES is overridden to 1 on CAN FD, so it doesn't
+        # affect the payload.)
+        hud_key = (bool(hud_control.lanesVisible), bool(alert_steer_required), bool(CS.out.steerFaultPermanent))
         if hud_key != self.lkas_hud_key:
           self.lkas_hud_key = hud_key
           self.lkas_state_change_frames = 30  # 3s at the 10Hz LKAS_HUD rate, matching stock pulse length
@@ -437,12 +446,15 @@ class CarController(CarControllerBase):
       lead_d = lead.dRel if lead.status else 0.0  # extend the lane out to the lead (0 = no lead)
       self.dash_lane = self.lane_path_fitter.update(self.model, CS.out.vEgo, lead_d)
       # Important: same mux for lane_path and hud_objects. Lane display freezes if muxes don't match.
-      mux = lane_path.MUX_CYCLE[(self.frame // 2) % len(lane_path.MUX_CYCLE)]
       if self.CP.carFingerprint in HONDA_BOSCH_CANFD:
+        # self.radar_mux advances one step per 50Hz tick (above), so the mux sweep stays contiguous
+        # across missed ticks, unlike a frame-derived mux.
+        mux = self.radar_mux
         # No LKAS_HUD_2 on CAN FD: the dash reads the lane length from the stock radar's in-band
         # terminator, so reshape the path into the terminated-prefix form (see lane_path.py).
         lane_offsets = lane_path.canfd_lane_offsets(self.dash_lane)
       else:
+        mux = lane_path.MUX_CYCLE[(self.frame // 2) % len(lane_path.MUX_CYCLE)]
         lane_offsets = self.dash_lane.offsets
       lane_msg = lane_path.create_lane_path(self.packer, self.CAN.lkas, lane_offsets, mux)
       can_sends.append(lane_msg)

--- a/opendbc/car/honda/hondacan.py
+++ b/opendbc/car/honda/hondacan.py
@@ -209,6 +209,12 @@ def create_lkas_hud(packer, bus, CP, hud_control, lat_active, steering_available
       lkas_hud_values['LKAS_PROBLEM'] = CS.out.steerFaultPermanent # CS.lkas_hud['LKAS_PROBLEM']
       lkas_hud_values['DASHED_LANES'] = 1  # show gray lanes when disengaged
 
+    if CP.carFingerprint in HONDA_BOSCH_CANFD:
+      # Don't let steer saturation flicker SOLID_LANES: every payload change must coincide with an
+      # LKAS_STATE_CHANGE pulse (see carcontroller), and a 10Hz flicker would keep the pulse
+      # re-triggering, which suppresses the dash lane lines.
+      lkas_hud_values['SOLID_LANES'] = hud_control.lanesVisible
+
   if not (CP.flags & HondaFlags.BOSCH_EXT_HUD):
     lkas_hud_values['RDM_OFF'] = 1
     lkas_hud_values['LANE_ASSIST_BEEP_OFF'] = 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!--
We need these details to verify your pull request.

Find your device's dongle ID and a route at https://connect.comma.ai.
Ideally, the route is recorded with the exact branch of your pull request.
-->
Validation
* Dongle ID: `ad9840558640c31d`
* Route: `00000039--3c4d72f493` (analyzed; fix not yet driven on-car)

## Why lanes weren't drawn

Decoded every transmitted `LANE_PATH` / `HUD_OBJECTS` / `RADAR_LEAD` / `LKAS_HUD` frame from the two routes:

* **`00000036--a39d1a8b6c`**: every one of the 1065 reassembled `LANE_PATH` sweeps was the 6-point idle pattern — the model never reached the car controller (fixed separately by the openpilot-side `modelV2` publishing commit `ecc5a92`).
* **`00000039--3c4d72f493`** (with `modelV2` wired up): real lane paths were transmitted (7–10 valid points at city speed), byte-faithful idle frames, `RADAR_LEAD` `LANE_PATH_LENGTH` in lockstep with the path (233/250 exact, rest ±1 in transitions, matching factory), `CNTR_REF` echoing `RADAR_REFERENCE` 250/250, `RADAR_LEAD` landing 120 ms after the reference like stock. **But `LKAS_STATE_CHANGE` was high during 100% of the frames where a real (>6-point) path was on the wire.** A high state-change bit suppresses the lane visualization (learning #4 from the factory-log analysis).

The pulse key included `steer_maxed` (via `SOLID_LANES = lanesVisible and not steer_maxed`). Torque saturation flickers at 10 Hz during city-speed steering, so each flicker restarted the 3-second pulse and the bit never fell while driving.

## Changes

1. **Pulse key** (`carcontroller.py`): key on exactly the signals that change the `LKAS_HUD` payload — `lanesVisible`, steer-required alert, permanent steer fault. `steer_maxed` and `latActive` are removed (`DASHED_LANES` is overridden to 1 on CAN FD, so `latActive` never changed the payload anyway).
2. **`SOLID_LANES` steadiness** (`hondacan.py`): on CAN FD, don't flicker `SOLID_LANES` with steer saturation, so every payload change again coincides with a state-change pulse, matching the stock camera's contract.
3. **Mux contiguity** (`carcontroller.py`): drive the `LANE_PATH`/`HUD_OBJECTS` mux from the tick-advanced `radar_mux` counter instead of frame parity. The frame-derived mux skipped a mux value on every missed 50 Hz tick (~640 skips in route 36, ~4% of steps in the critical window of route 39), leaving holes in the sweep that the stock radar never produces.

## Verification

Simulated the real `CarController` (MDX 4G MMR, op longitudinal) for 30 s at 100 Hz with 10 Hz torque-saturation flicker, a `latActive` dropout, and missed 50 Hz ticks:

* one 30-frame `LKAS_STATE_CHANGE` pulse at engagement, then low for the remaining 21.7 s (previously: high indefinitely)
* `SOLID_LANES` steady while engaged
* mux steps always exactly +1 through the 1–10/17–26/33–42/49–58 banks across missed ticks; `LANE_PATH` and `HUD_OBJECTS` muxes identical every frame

`ruff check .` passes; `opendbc.car.tests.test_car_interfaces` (256 tests) and Honda tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2171f5a1-9e33-49a6-b8c2-de9577f6a744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2171f5a1-9e33-49a6-b8c2-de9577f6a744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

