### PR TITLE
Honda CAN FD: match stock LANE_PATH length law (lanes still not rendering, route 0000003b)

### DIFF
--- a/opendbc/car/honda/lane_path.py
+++ b/opendbc/car/honda/lane_path.py
@@ -61,13 +61,22 @@ CANFD_MAX_VALID_PTS = 23
 CANFD_MIN_VALID_PTS = 6
 CANFD_IDLE_OFFSETS = [0] * CANFD_MIN_VALID_PTS + [OFFSET_UNAVAILABLE] * (NUM_PTS - CANFD_MIN_VALID_PTS)
 
+# Stock valid-point count is a linear function of ego speed alone: len = 6.74 + 0.862*vEgo (m/s), clamped
+# to [6, 23]. Fit from the factory lanes-on route (~1200 RADAR_LEAD frames vs wheel speed; residuals flat
+# against lead distance, so no lead term). At city speed this is roughly double a plain 23*vEgo/27 ramp
+# (e.g. 16 points at 38 km/h where the ramp gives 9); matching it matters because the dash never rendered
+# openpilot's shorter-than-stock paths.
+CANFD_LEN_INTERCEPT = 6.74
+CANFD_LEN_SLOPE = 0.862  # points per m/s
+
 
 def canfd_lane_length(dash_lane) -> int:
   """Valid-point count of the stock-form path. The stock radar mirrors this in RADAR_LEAD's
   LANE_PATH_LENGTH signal (6 when idle), which the dash cross-checks against the in-band terminator."""
   if dash_lane.reach <= 0.0 or dash_lane.offsets[0] == OFFSET_UNAVAILABLE:
     return CANFD_MIN_VALID_PTS
-  return max(CANFD_MIN_VALID_PTS, min(CANFD_MAX_VALID_PTS, round(dash_lane.reach * CANFD_MAX_VALID_PTS)))
+  n = round(CANFD_LEN_INTERCEPT + CANFD_LEN_SLOPE * dash_lane.v_ego)
+  return max(CANFD_MIN_VALID_PTS, min(CANFD_MAX_VALID_PTS, n))
 
 
 def canfd_lane_offsets(dash_lane) -> list[int]:
@@ -144,6 +153,7 @@ class DashLane:
   left_line: bool
   right_line: bool
   lane_cross: int = 0
+  v_ego: float = 0.0   # m/s at fit time; drives the CAN FD valid-point count (stock law is speed-only)
 
 
 class LanePathFitter:
@@ -170,4 +180,4 @@ class LanePathFitter:
     reach = float(np.clip(max(v_ego / DASH_PATH_FULL_LEN_SPEED, lead_d / DASH_PATH_LEAD_FULL_DIST, DASH_PATH_MIN_REACH), 0.0, 1.0))
     if round(reach * LANE_LENGTH_MAX_VALUE) <= 0:
       return blank
-    return DashLane(encode_lane_path(x, y), reach, left_on, right_on)
+    return DashLane(encode_lane_path(x, y), reach, left_on, right_on, v_ego=v_ego)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

Lane lines still did not render in `ad9840558640c31d/0000003b--ee000ddeb6`, the first drive with both the modelV2 plumbing (openpilot `ecc5a92`) and the LKAS_STATE_CHANGE pulse fix (#611) on board (opendbc `871a07d`, openpilot `69ac424`).

## Log analysis (route 0000003b)

Ran the standard checklist against the rlog; everything previously identified is now clean:

- Sweeps well-formed: contiguous valid prefix + 2047 terminator, no valid points after a terminator, mux steps all +1, LANE_PATH/HUD_OBJECTS mux equal on every frame.
- LKAS_HUD byte-identical to the factory lanes-on payload (`01440048180000`) with the state-change bit held low for a clean 15 s engaged window (22–37 s); pulses were exactly ~3 s and only on real payload changes (no re-trigger).
- RADAR_LEAD `LANE_PATH_LENGTH` in exact lockstep with the sweep, `CNTR_REF` echo consistent, sent 120 ms after `RADAR_REFERENCE`, `TARGET_SPEED` 140 (same value the stock radar sent while parked in this log's first 8 s).
- Bus 0 address set and rates match the factory lanes-on route exactly (only addition: the tester-present keeping the radar disabled).

Yet no lanes. The one remaining content difference: **path length**.

## Root cause

Fitting the factory lanes-on route (~1200 RADAR_LEAD frames vs wheel speed):

```
valid points = 6.74 + 0.862 * vEgo (m/s), clamped [6, 23]
```

Speed-only — residuals are flat against lead distance. The old formula `round(reach * 23)` with `reach = max(v/27, lead/70, 0.15)` has the right slope but **no intercept**, so openpilot has been sending roughly half the stock path length at city speed: 8–9 points at 38 km/h where the stock radar sends 16. Every on-car test drive so far has been at city speed, so the path was always far short of what the dash sees from the factory radar under identical conditions.

| speed | stock (fit/observed) | old formula | new |
|---|---|---|---|
| 10 km/h | 9 | 6 | 9 |
| 30 km/h | 14–15 | 8 | 14 |
| 38 km/h | 16 | 9 | 16 |
| 60 km/h | 21–22 | 15 | 21 |
| ≥70 km/h | 23 | 16+ | 23 |

## Change

- `DashLane` carries `v_ego` from the fitter.
- `canfd_lane_length()` uses the stock law `round(6.74 + 0.862*vEgo)` clamped [6, 23]; lead-distance term dropped (not present in stock data). Idle/blank behavior (6 zero points) unchanged.
- Radarless path (`reach` → LKAS_HUD_2) unchanged.

## Verification

- Offline harness (real `CarController`, stubbed Params, MDX 4G MMR + op long, emulated radar ticks): sweep valid-count and RADAR_LEAD length match the law exactly and stay in lockstep at 0/10/20/30/38/50/60/70/80/100 km/h.
- `opendbc/car/honda/tests/test_honda.py` passes.

## Also learned (no code change)

The "CNTR_REF must echo RADAR_REFERENCE COUNTER at ~120 ms" rule doesn't hold as an echo: the factory route shows a constant **+2** offset at ~100 ms, this car's stock radar (parked) a constant **+1** at ~155 ms. It behaves like a free-running 5 Hz counter with arbitrary per-session phase, so our constant-offset behavior is within the observed stock family and was left alone.

Needs an on-car drive to confirm; a stretch above ~50 km/h would also cross into the length range where the factory ground truth definitively had lanes displayed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a6361ec-2773-423c-b557-574b82945867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a6361ec-2773-423c-b557-574b82945867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

