### PR TITLE
Honda CAN FD: RADAR_LEAD lane-line status bits — the missing dash lane-render gate

### DIFF
--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -251,8 +251,12 @@ class CarController(CarControllerBase):
       if CS.radar_5hz_tick:
         # RADAR_LEAD's LANE_PATH_LENGTH must track the valid-point count of the LANE_PATH sweep we are
         # authoring; the stock radar keeps the two in lockstep and the dash won't draw lanes otherwise.
+        # LEFT_LANE/RIGHT_LANE carry the per-side line-detected status (3/0) the same way the stock
+        # radar mirrors the camera's LANE_LINES bits; the dash draws no lane lines while both are 0.
         radar_msgs.extend(hondacan.create_canfd_5hz_radar_messages(self.packer, self.CAN.pt, CS.radar_ref_counter,
-                                                                   lane_path.canfd_lane_length(self.dash_lane)))
+                                                                   lane_path.canfd_lane_length(self.dash_lane),
+                                                                   lane_path.LANE_LINE_ON if self.dash_lane.left_line else 0,
+                                                                   lane_path.LANE_LINE_ON if self.dash_lane.right_line else 0))
 
       # mirror each packed frame onto both the powertrain bus and the camera bus
       for addr, dat, _ in radar_msgs:

--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -155,6 +155,10 @@ class CarController(CarControllerBase):
     self.windfactor_before_gasmax = self.windfactor_before_brake = self.windfactor
     self.pitch = 0.0
     self.radar_mux = 0
+    # stock RADAR_HUD_CANFD raises its CMBS bit only for a short burst after ACC engages (see
+    # create_radar_hud_canfd); counted in 10 Hz hud ticks
+    self.radar_hud_pulse = 0
+    self.last_acc_enabled = False
 
     # Bosch extra-brake controller
     self.brake_pid = PIDController(k_p=([0,], [0,]),
@@ -224,9 +228,14 @@ class CarController(CarControllerBase):
     # so the packer's counter/checksum only advance once per cycle, then the identical bytes are
     # mirrored onto both buses (re-packing would double-increment the counter and desync the buses).
     if (self.CP.carFingerprint in HONDA_BOSCH_CANFD) and self.CP.openpilotLongitudinalControl:
+      if CC.enabled and not self.last_acc_enabled:
+        self.radar_hud_pulse = 30  # ~3 s at 10 Hz, matching the stock 2-6 s engage burst
+      self.last_acc_enabled = CC.enabled
       radar_msgs = []
       if CS.hud_tick:
-        radar_msgs.append(hondacan.create_radar_hud_canfd(self.packer, self.CAN.pt, CC.enabled))
+        radar_msgs.append(hondacan.create_radar_hud_canfd(self.packer, self.CAN.pt, CC.enabled, self.radar_hud_pulse > 0))
+        if self.radar_hud_pulse > 0:
+          self.radar_hud_pulse -= 1
       if CS.supp_tick:
         radar_msgs.append(hondacan.create_canfd_supplemental(self.packer, self.CAN.pt))
       if CS.radar_50hz_tick:

--- a/opendbc/car/honda/hondacan.py
+++ b/opendbc/car/honda/hondacan.py
@@ -258,9 +258,11 @@ def spam_buttons_command(packer, CAN, button_val, car_fingerprint):
   return packer.make_can_msg("SCM_BUTTONS", bus, values)
 
 
-def create_radar_hud_canfd(packer, bus, acc):
+def create_radar_hud_canfd(packer, bus, acc, acc_pulse=False):
   values = {
-    'CMBS_ENABLED_MAYBE': acc,
+    # The stock radar only raises this bit in short (~2-6 s) bursts right after ACC engages/resumes,
+    # then drops it for the rest of the drive; it is never held for a whole engagement.
+    'CMBS_ENABLED_MAYBE': 1 if (acc and acc_pulse) else 0,
     'ACC_ON': acc,
     'SET_ME_X01': 0x01,
     'SET_ME_X01_2': 0x01,

--- a/opendbc/car/honda/hondacan.py
+++ b/opendbc/car/honda/hondacan.py
@@ -322,7 +322,7 @@ def create_canfd_50hz_radar_messages(packer, bus, radar_mux):
   return commands
 
 
-def create_canfd_5hz_radar_messages(packer, bus, radar_ref_cntr, lane_path_length=6):
+def create_canfd_5hz_radar_messages(packer, bus, radar_ref_cntr, lane_path_length=6, left_lane=0, right_lane=0):
   commands = []
 
   radar_lead_values = {
@@ -330,6 +330,11 @@ def create_canfd_5hz_radar_messages(packer, bus, radar_ref_cntr, lane_path_lengt
     'SET_ME_X01': 0x01,
     # stock radar transmits a constant 140 here (confirmed from logs); 120 causes a camera mismatch
     'TARGET_SPEED_MAYBE': 140,
+    # stock: per-side lane-line detection status (3 = line present, 0 = none), in lockstep with the
+    # camera's LKAS_HUD LANE_LINES bits. This is the CAN FD counterpart of radarless LKAS_HUD_2's
+    # LEFT_LANE/RIGHT_LANE; the dash does not draw lane lines while both are 0.
+    'LEFT_LANE': left_lane,
+    'RIGHT_LANE': right_lane,
     # stock: number of valid points in the current LANE_PATH sweep (6 = idle). The dash cross-checks
     # this against the path's in-band 2047 terminator; a mismatch suppresses the lane-line rendering.
     'LANE_PATH_LENGTH': lane_path_length,

--- a/opendbc/dbc/generator/honda/honda_common_canfd.dbc
+++ b/opendbc/dbc/generator/honda/honda_common_canfd.dbc
@@ -49,6 +49,8 @@ BO_ 254913116 RADAR_LEAD: 8 XXX
  SG_ SET_ME_X01 : 5|1@0+ (1,0) [0|1] "" XXX
  SG_ CNTR_REF : 7|2@0+ (1,0) [0|3] "" XXX
  SG_ TARGET_SPEED_MAYBE : 15|8@0+ (1,0) [0|255] "" XXX
+ SG_ LEFT_LANE : 23|2@0+ (1,0) [0|3] "" XXX
+ SG_ RIGHT_LANE : 21|2@0+ (1,0) [0|3] "" XXX
  SG_ LANE_PATH_LENGTH : 31|6@0+ (1,0) [0|63] "" XXX
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" XXX
@@ -69,3 +71,5 @@ BO_ 1872 RADAR_50HZ_TICK_REFERENCE: 16 XXX
  SG_ IGNORE : 11|1@0+ (1,0) [0|1] "" XXX
 
 CM_ SG_ 254913116 LANE_PATH_LENGTH "number of valid LANE_PATH points in the current sweep (6 = idle/no lane, up to 23-24); the dash needs this to match the in-band 2047 terminator to draw the lane lines";
+CM_ SG_ 254913116 LEFT_LANE "3 = left lane line detected, 0 = none; tracks the camera's LKAS_HUD LANE_LINES bit 1 exactly in factory logs. The CAN FD equivalent of radarless LKAS_HUD_2 LEFT_LANE; the dash won't draw the lane lines while both are 0";
+CM_ SG_ 254913116 RIGHT_LANE "3 = right lane line detected, 0 = none; tracks the camera's LKAS_HUD LANE_LINES bit 0 exactly in factory logs. The CAN FD equivalent of radarless LKAS_HUD_2 RIGHT_LANE; the dash won't draw the lane lines while both are 0";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

Lanes still didn't render in route `00000042--ebad73a097` (8.7 mi, up to 100 km/h, opendbc `4f017f7` — includes the #612 length law, verified on the wire: length residuals vs the stock law were 0 for 97% of RADAR_LEAD frames, 13 minutes at length ≥ 15 including long full-23 stretches). Per request, did a full byte-level comparison of **all** HUD/dash messages between the factory lanes-on route and this drive, restricted to lanes-expected conditions (path length ≥ 15).

## What matched

`LKAS_HUD` (payload + pulse behavior), `LANE_PATH` structure, `HUD_OBJECTS`, `BOSCH_SUPPLEMENTAL_CANFD`, `0x6CD5555` (byte-identical constant in both), bus-0 address set and rates. `0x35E` differences turned out to be `CAMERA_MESSAGES` — the live camera's own content (speed-limit sign detection etc.) forwarded by panda, not something openpilot authors. `RADAR_LEAD2`'s `8878...` is the radar's "no target" idle form (our car's stock radar sends exactly this parked), left alone since the dash demonstrably accepts our object stream (lead icon renders).

## The gate: RADAR_LEAD byte 2

Factory sets byte 2's top nibble to `0xf0` while driving with lanes; we always send `0x00`. It decodes as **two 2-bit per-side lane-line status fields** that track the camera's `LKAS_HUD.LANE_LINES` bits transition-for-transition in the factory log:

| time (factory route) | LKAS_HUD LANE_LINES | RADAR_LEAD byte2 |
|---|---|---|
| driving, both lines | 3 | `0xf0` |
| 152–158 s, one line | 1 | `0x30` |
| ~188 s, other line | 2 | `0xc0` |
| ~194 s, no lines | 0 | `0x00` |

This is the CAN FD counterpart of radarless `LKAS_HUD_2.LEFT_LANE/RIGHT_LANE` — which that dash *requires* (value 3) to draw lane lines. We've been broadcasting "no lane lines detected" at 5 Hz the entire time, so the dash never drew the path no matter how byte-perfect it was. Our car's stock radar, parked with no lanes in view, also sends `0x00` — consistent.

**Change:** new `LEFT_LANE`/`RIGHT_LANE` signals (23|2, 21|2) in the DBC, fed from `DashLane`'s per-side trusted-line flags (3 when drawing, 0 when blank).

## Secondary: RADAR_HUD_CANFD CMBS bit

Factory raises `CMBS_ENABLED_MAYBE` only in 2–6 s bursts right after ACC engages/resumes (`0xa1` → `0x81` steady). We held it high for the whole engagement — the same held-transient anti-pattern as the LKAS_STATE_CHANGE bug. Now pulsed for 30 hud ticks (~3 s) on the `CC.enabled` rising edge.

## Verification

Offline harness (real `CarController`, MDX 4G MMR + op long, emulated ticks, engage/disengage/re-engage cycle):
- `RADAR_LEAD` byte 2 = `0xf0` whenever the lane path is drawn, `0x00` when blank.
- `RADAR_HUD_CANFD` byte 6: `0x01` → `0xa1` for exactly 3 s on engage → `0x81` steady → `0x01` on disengage; re-engage pulses again — matching the factory sequence.
- Length-law speed sweep from #612 still passes at all speeds (0–100 km/h), RADAR_LEAD in lockstep.
- `opendbc/car/honda/tests/test_honda.py` passes.

Needs an on-car drive to confirm the dash finally draws the lanes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a6361ec-2773-423c-b557-574b82945867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a6361ec-2773-423c-b557-574b82945867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

