### PR TITLE
Honda CAN-FD: clear brake-module DTCs before radar disable to prevent CRUISE_FAULT (accFaulted)

### DIFF
--- a/opendbc/car/disable_ecu.py
+++ b/opendbc/car/disable_ecu.py
@@ -1,3 +1,4 @@
+from opendbc.car.can_definitions import CanData
 from opendbc.car.carlog import carlog
 from opendbc.car.isotp_parallel_query import IsoTpParallelQuery
 
@@ -9,6 +10,26 @@ COM_CONT_RESPONSE = b''
 # UDS 0x14 ClearDiagnosticInformation for all DTC groups (0xFFFFFF), positive response 0x54
 CLEAR_DTC_REQUEST = b'\x14\xff\xff\xff'
 CLEAR_DTC_RESPONSE = b'\x54'
+
+# 29-bit functional (broadcast) diagnostic address; targets every ECU on the bus
+FUNCTIONAL_ADDR_29BIT = 0x18DB33F1
+# ISO-TP single frame carrying CLEAR_DTC_REQUEST (0x14 ClearDiagnosticInformation, all groups)
+CLEAR_DTC_ISOTP_SF = bytes([len(CLEAR_DTC_REQUEST)]) + CLEAR_DTC_REQUEST + b'\x00' * (7 - len(CLEAR_DTC_REQUEST))
+
+
+def clear_all_dtcs(can_send, buses, functional_addr=FUNCTIONAL_ADDR_29BIT):
+  """Broadcast UDS 0x14 ClearDiagnosticInformation (all DTC groups) to every ECU on the given buses
+  using the functional (broadcast) address. Best-effort; no responses are collected.
+
+  This is used to clear stored DTCs that other ECUs may have latched due to a disabled radar, so they
+  don't report stale faults on a later drive.
+
+  WARNING: this clears stored DTCs on ALL ECUs on the bus, including unrelated and safety-relevant
+  modules, so genuine fault codes are erased too. Only use it when you specifically need to clear
+  cross-ECU faults."""
+  for bus in buses:
+    carlog.warning(f"clear all DTCs (functional) on bus {bus} ...")
+    can_send([CanData(functional_addr, CLEAR_DTC_ISOTP_SF, bus)])
 
 
 def disable_ecu(can_recv, can_send, bus=0, addr=0x7d0, sub_addr=None, com_cont_req=b'\x28\x83\x01', timeout=0.1, retry=10, clear_dtc=False):

--- a/opendbc/car/honda/interface.py
+++ b/opendbc/car/honda/interface.py
@@ -2,7 +2,7 @@
 import numpy as np
 from opendbc.car import get_safety_config, structs, uds
 from opendbc.car.common.conversions import Conversions as CV
-from opendbc.car.disable_ecu import disable_ecu
+from opendbc.car.disable_ecu import disable_ecu, clear_all_dtcs
 from opendbc.car.honda.hondacan import CanBus
 from opendbc.car.honda.values import CarControllerParams, HondaFlags, CAR, HONDA_BOSCH, HONDA_BOSCH_CANFD, \
                                                  HONDA_NIDEC_ALT_SCM_MESSAGES, HONDA_BOSCH_RADARLESS, HondaSafetyFlags
@@ -340,6 +340,10 @@ class CarInterface(CarInterfaceBase):
         # previous drive don't fault the brake module at startup.
         clear_dtc = CP.carFingerprint in HONDA_BOSCH_CANFD
       disable_ecu(can_recv, can_send, bus=CanBus(CP).pt, addr=0x18DAB0F1, com_cont_req=communication_control, clear_dtc=clear_dtc)
+      if clear_dtc:
+        # Also clear DTCs on the other ECUs (powertrain and camera buses) that may have latched a
+        # fault from the missing radar, so they don't report stale codes on a later drive.
+        clear_all_dtcs(can_send, [CanBus(CP).pt, CanBus(CP).camera])
 
   @staticmethod
   def deinit(CP, can_recv, can_send):

--- a/opendbc/car/honda/interface.py
+++ b/opendbc/car/honda/interface.py
@@ -339,11 +339,20 @@ class CarInterface(CarInterfaceBase):
         # The CAN FD radar stores DTCs while disabled; clear them on disable so stale codes from a
         # previous drive don't fault the brake module at startup.
         clear_dtc = CP.carFingerprint in HONDA_BOSCH_CANFD
-      disable_ecu(can_recv, can_send, bus=CanBus(CP).pt, addr=0x18DAB0F1, com_cont_req=communication_control, clear_dtc=clear_dtc)
       if clear_dtc:
-        # Also clear DTCs on the other ECUs (powertrain and camera buses) that may have latched a
-        # fault from the missing radar, so they don't report stale codes on a later drive.
+        # The brake module (VSA) latches a radar lost-communication DTC when the radar goes silent for
+        # more than ~0.1 s at cutover. The DTC matures over trips (Honda two-trip detection): once it is
+        # confirmed from a previous drive, the very next comm-loss detection trips BRAKE_MODULE.CRUISE_FAULT
+        # (accFaulted) ~0.16 s after the radar is silenced, and it stays set for the whole drive. Only a
+        # drive with the radar alive (openpilot longitudinal off) heals it.
+        # Broadcast-clear stored DTCs on all ECUs (powertrain and camera buses) BEFORE silencing the radar:
+        # the maturation counter is reset every drive, so this drive's comm-loss stays a first-trip pending
+        # code that never faults. Clearing must happen before the disable because the fault trips ~0.16 s
+        # after radar silence while a DTC clear can take an ECU several hundred ms to process.
+        # NOTE: init() runs while the panda is still in the ELM327 safety mode, which allows the 29-bit
+        # functional diagnostic address on every bus, so the car safety mode needs no TX allowlist entry.
         clear_all_dtcs(can_send, [CanBus(CP).pt, CanBus(CP).camera])
+      disable_ecu(can_recv, can_send, bus=CanBus(CP).pt, addr=0x18DAB0F1, com_cont_req=communication_control, clear_dtc=clear_dtc)
 
   @staticmethod
   def deinit(CP, can_recv, can_send):

--- a/opendbc/safety/modes/honda.h
+++ b/opendbc/safety/modes/honda.h
@@ -359,7 +359,9 @@ static safety_config honda_bosch_init(uint16_t param) {
                                               {0x310, 0, 8, .check_relay = false}, {0x6CD5558, 0, 8, .check_relay = true}, {0x6CD5559, 0, 8, .check_relay = false},
                                               {0xF31AA52, 0, 8, .check_relay = false}, {0xF31AA5C, 0, 8, .check_relay = true}, {0x1A45AA4E, 0, 8, .check_relay = false},
                                               {0x310, 2, 8, .check_relay = false}, {0x6CD5558, 2, 8, .check_relay = true}, {0x6CD5559, 2, 8, .check_relay = false},
-                                              {0xF31AA52, 2, 8, .check_relay = false}, {0xF31AA5C, 2, 8, .check_relay = true}, {0x1A45AA4E, 2, 8, .check_relay = false}};
+                                              {0xF31AA52, 2, 8, .check_relay = false}, {0xF31AA5C, 2, 8, .check_relay = true}, {0x1A45AA4E, 2, 8, .check_relay = false},
+                                              // functional (broadcast) diagnostic address, used to clear stale DTCs on radar disable (both buses)
+                                              {0x18DB33F1, 0, 8, .check_relay = false}, {0x18DB33F1, 2, 8, .check_relay = false}};
 
   const uint16_t HONDA_PARAM_ALT_BRAKE = 1;
   const uint16_t HONDA_PARAM_RADARLESS = 8;

--- a/opendbc/safety/modes/honda.h
+++ b/opendbc/safety/modes/honda.h
@@ -359,9 +359,7 @@ static safety_config honda_bosch_init(uint16_t param) {
                                               {0x310, 0, 8, .check_relay = false}, {0x6CD5558, 0, 8, .check_relay = true}, {0x6CD5559, 0, 8, .check_relay = false},
                                               {0xF31AA52, 0, 8, .check_relay = false}, {0xF31AA5C, 0, 8, .check_relay = true}, {0x1A45AA4E, 0, 8, .check_relay = false},
                                               {0x310, 2, 8, .check_relay = false}, {0x6CD5558, 2, 8, .check_relay = true}, {0x6CD5559, 2, 8, .check_relay = false},
-                                              {0xF31AA52, 2, 8, .check_relay = false}, {0xF31AA5C, 2, 8, .check_relay = true}, {0x1A45AA4E, 2, 8, .check_relay = false},
-                                              // functional (broadcast) diagnostic address, used to clear stale DTCs on radar disable (both buses)
-                                              {0x18DB33F1, 0, 8, .check_relay = false}, {0x18DB33F1, 2, 8, .check_relay = false}};
+                                              {0xF31AA52, 2, 8, .check_relay = false}, {0xF31AA5C, 2, 8, .check_relay = true}, {0x1A45AA4E, 2, 8, .check_relay = false}};
 
   const uint16_t HONDA_PARAM_ALT_BRAKE = 1;
   const uint16_t HONDA_PARAM_RADARLESS = 8;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On CAN-FD Bosch Honda with openpilot longitudinal, `BRAKE_MODULE.CRUISE_FAULT` (0x1BE byte2 bit6 → `carState.accFaulted`) sets shortly after the radar is UDS-disabled and never clears for the rest of the drive, blocking ACC. It never happens with openpilot longitudinal off, tends to appear on second-and-later consecutive openpilot drives, and heals only after a drive with the radar alive.

## Root cause (from rlog analysis, dongle `3792d010590cb83a`)

The brake module (VSA) monitors the radar's ACC control messages (0x1DF/0x1EF, 50 Hz) and detects lost communication when they go stale for more than ~0.1 s. Detection alone does not fault — it stores a first-trip *pending* DTC. Honda uses multi-trip DTC maturation: once the DTC is *confirmed* from a previous drive, the very next comm-loss detection trips `CRUISE_FAULT` ~0.16 s after the radar goes silent, and only a trip with the radar alive (openpilot long off) heals it.

Evidence across 7 analyzed drives:

| route | 0x1DF takeover gap | result |
|---|---|---|
| `000000ed` | 234 ms | CRUISE_FAULT at disable+0.160 s |
| `000000f6` | 113 ms | CRUISE_FAULT at disable+0.153 s |
| `0000010e` | 124 ms | CRUISE_FAULT at disable+0.164 s |
| `0000010f` | 154 ms | CRUISE_FAULT at disable+0.144 s |
| `0000010a` | 74 ms | clean (71 min) |
| `00000042` (new MDX) | 100 ms | clean |
| `0000003e` (new MDX) | 70 ms | clean |

openpilot already clears the **radar's** DTCs at init, but the brake module is a separate ECU whose stored comm-loss DTC was never touched — so it matures and re-faults drive after drive.

## Fix

Broadcast UDS ClearDiagnosticInformation (`14 FF FF FF` on functional address `0x18DB33F1`, powertrain + camera buses) in `CarInterface.init()` **before** silencing the radar. This resets every ECU's maturation state each drive, so the comm-loss at cutover stays a first-trip pending code that never trips `CRUISE_FAULT`.

Ordering matters: the fault trips ~0.16 s after radar silence, while a DTC clear can take an ECU several hundred ms to process (the radar's own clear takes ~620 ms with a `0x78` responsePending), so clearing after the disable races the latch.

No car-safety TX allowlist change is needed: `init()` runs while the panda is still in the ELM327 safety mode, which already allows the functional diagnostic address on every bus (this is also how the existing `10 03`/`14`/`28 83 03` radar sequence gets through today). Deliberately *not* allowing `0x18DB33F1` in the driving safety mode avoids permitting arbitrary broadcast UDS (e.g. ECUReset) at speed. The `deinit()`/re-enable path does not broadcast (`clear_dtc` stays False there).

## Verification

- `opendbc/safety/tests/test_honda.py`: 344 tests, OK (safety mode untouched relative to base).
- `ruff check` clean on changed files.
- Mocked `CarInterface.init()`: broadcast frame `04 14 ff ff ff 00 00 00` (byte-identical ISO-TP form to the radar-targeted clear proven working in route `00000042`) sent on buses 0 and 2 before any radar disable query; `deinit()` sends none.

## Notes for on-car test

- Needs two consecutive openpilot-long drives to confirm (the fault requires a matured DTC from the prior drive). Watch `BRAKE_MODULE.CRUISE_FAULT` and `cruiseState.available` in the second drive.
- Caveat: the broadcast erases stored DTCs on **all** ECUs each drive, so genuine fault codes are wiped too (mechanic-visible history is lost).
- Follow-up option if any fault survives: the takeover gap itself (disable→relay-open, 70–234 ms jitter) could be closed by deferring the CommunicationControl until after the relay opens; that also addresses the camera RDM_PROBLEM latch, which follows the same staleness pattern (budgets ~350 ms for 5 Hz RADAR_LEAD, ~1.05 s for 1 Hz BOSCH_SUPP).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-936e4bad-1452-46c2-a250-cdf9e431e38b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-936e4bad-1452-46c2-a250-cdf9e431e38b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

