### PR TITLE
Honda CAN FD: defer radar disable until relay open; fail-safe SCM_BUTTONS takeover

### DIFF
--- a/opendbc/car/disable_ecu.py
+++ b/opendbc/car/disable_ecu.py
@@ -32,6 +32,31 @@ def clear_all_dtcs(can_send, buses, functional_addr=FUNCTIONAL_ADDR_29BIT):
     can_send([CanData(functional_addr, CLEAR_DTC_ISOTP_SF, bus)])
 
 
+def clear_ecu_dtcs(can_recv, can_send, bus=0, addr=0x7d0, sub_addr=None, timeout=0.1, retry=10):
+  """Enter the extended diagnostic session and clear an ECU's stored DTCs (UDS 0x14), without
+  disabling its communication."""
+  carlog.warning(f"ecu clear DTCs {hex(addr), sub_addr} ...")
+
+  for i in range(retry):
+    try:
+      query = IsoTpParallelQuery(can_send, can_recv, bus, [(addr, sub_addr)], [EXT_DIAG_REQUEST], [EXT_DIAG_RESPONSE])
+
+      for _, _ in query.get_data(timeout).items():
+        carlog.warning("clear diagnostic information ...")
+        query = IsoTpParallelQuery(can_send, can_recv, bus, [(addr, sub_addr)], [CLEAR_DTC_REQUEST], [CLEAR_DTC_RESPONSE])
+        query.get_data(timeout)
+
+        carlog.warning("ecu DTCs cleared")
+        return True
+
+    except Exception:
+      carlog.exception("ecu clear DTCs exception")
+
+    carlog.error(f"ecu clear DTCs retry ({i + 1}) ...")
+  carlog.error("ecu clear DTCs failed")
+  return False
+
+
 def disable_ecu(can_recv, can_send, bus=0, addr=0x7d0, sub_addr=None, com_cont_req=b'\x28\x83\x01', timeout=0.1, retry=10, clear_dtc=False):
   """Silence an ECU by disabling sending and receiving messages using UDS 0x28.
   The ECU will stay silent as long as openpilot keeps sending Tester Present.

--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -151,6 +151,7 @@ class CarController(CarControllerBase):
 
     self.lkas_button_send_remaining = 0
     self.last_lkas_button_frame = 0
+    self.radar_disable_counter = 0
 
     self.gasfactor = 1.0 if (Params().get("HondaGasFactorParams") is None) else Params().get("HondaGasFactorParams")
     self.gasfactor_before_gasmax = self.gasfactor
@@ -218,9 +219,27 @@ class CarController(CarControllerBase):
     # Send CAN commands
     can_sends = []
 
-    # tester present - w/ no response (keeps radar disabled)
     if self.CP.carFingerprint in (HONDA_BOSCH - HONDA_BOSCH_RADARLESS) and self.CP.openpilotLongitudinalControl:
-      if self.frame % 10 == 0:
+      if self.CP.carFingerprint in HONDA_BOSCH_CANFD and CS.stock_acc_alive:
+        # CAN FD: the radar is still transmitting. It is silenced from here rather than from
+        # CarInterface.init(), and only once the comma relay is confirmed open: init() ran while the
+        # panda was still in the ELM327 safety mode, so the replacement ACC_CONTROL stream was blocked
+        # until the safety-mode switch landed, and whenever the switch took longer than ~110 ms after
+        # the radar went silent the brake module latched CRUISE_FAULT (accFaulted) for the whole drive.
+        # With the relay already open the stock radar keeps feeding the brake module (and, via panda
+        # forwarding, the camera) right up to the switchover, and the replacement stream starts within
+        # a few frames of radar silence (see CS.stock_acc_alive), well inside the fault threshold.
+        if CS.canfd_relay_open:
+          if self.radar_disable_counter % 50 == 0:
+            # UDS extended diagnostic session, required before CommunicationControl
+            can_sends.append((0x18DAB0F1, b'\x02\x10\x03\x00\x00\x00\x00\x00', self.CAN.pt))
+          elif self.radar_disable_counter % 50 == 5:
+            # UDS CommunicationControl disableRxAndTx (0x80 suppresses the response); the same request
+            # CarInterface.init() used to send, retried every 0.5 s until the radar goes silent
+            can_sends.append((0x18DAB0F1, b'\x03\x28\x83\x03\x00\x00\x00\x00', self.CAN.pt))
+          self.radar_disable_counter += 1
+      elif self.frame % 10 == 0:
+        # tester present - w/ no response (keeps radar disabled)
         bus = 0 if self.CP.carFingerprint in HONDA_BOSCH_CANFD else 1
         can_sends.append(make_tester_present_msg(0x18DAB0F1, bus, suppress_response=True))
 
@@ -230,7 +249,9 @@ class CarController(CarControllerBase):
     # open relay, so they must be sent explicitly on both buses. Each message is packed exactly once
     # so the packer's counter/checksum only advance once per cycle, then the identical bytes are
     # mirrored onto both buses (re-packing would double-increment the counter and desync the buses).
-    if (self.CP.carFingerprint in HONDA_BOSCH_CANFD) and self.CP.openpilotLongitudinalControl:
+    # While the stock radar is still transmitting (drive start, before the deferred disable above has
+    # silenced it), it authors all of these itself: sending look-alikes too would double them up.
+    if (self.CP.carFingerprint in HONDA_BOSCH_CANFD) and self.CP.openpilotLongitudinalControl and not CS.stock_acc_alive:
       if CC.enabled and not self.last_acc_enabled:
         self.radar_hud_pulse = 30  # ~3 s at 10 Hz, matching the stock 2-6 s engage burst
       self.last_acc_enabled = CC.enabled
@@ -324,9 +345,9 @@ class CarController(CarControllerBase):
         can_sends.append(hondacan.create_bosch_supplemental_1(self.packer, self.CAN))
       # If using stock ACC, spam cancel command to kill gas when OP disengages.
       if pcm_cancel_cmd:
-        can_sends.append(hondacan.spam_buttons_command(self.packer, self.CAN, CruiseButtons.CANCEL, 0, self.CP.carFingerprint))
+        can_sends.append(hondacan.spam_buttons_command(self.packer, self.CAN, CruiseButtons.CANCEL, 0, CS.scm_ambient_light, self.CP.carFingerprint))
       elif CC.cruiseControl.resume:
-        can_sends.append(hondacan.spam_buttons_command(self.packer, self.CAN, CruiseButtons.RES_ACCEL, 0, self.CP.carFingerprint))
+        can_sends.append(hondacan.spam_buttons_command(self.packer, self.CAN, CruiseButtons.RES_ACCEL, 0, CS.scm_ambient_light, self.CP.carFingerprint))
 
     else:
       # Send gas and brake commands.
@@ -382,8 +403,11 @@ class CarController(CarControllerBase):
 
           stopping = actuators.longControlState == LongCtrlState.stopping
           self.stopping_counter = self.stopping_counter + 1 if stopping else 0
-          can_sends.extend(hondacan.create_acc_commands(self.packer, self.CAN, CC.enabled, CC.longActive, self.accel, self.gas,
-                                                        self.stopping_counter, self.CP.carFingerprint, gas_pedal_force))
+          # CAN FD: never overlap the stock radar's own ACC_CONTROL stream; ours starts within a few
+          # frames of the radar going silent (see the deferred radar disable above)
+          if not (self.CP.carFingerprint in HONDA_BOSCH_CANFD and CS.stock_acc_alive):
+            can_sends.extend(hondacan.create_acc_commands(self.packer, self.CAN, CC.enabled, CC.longActive, self.accel, self.gas,
+                                                          self.stopping_counter, self.CP.carFingerprint, gas_pedal_force))
         else:
           apply_brake = np.clip(self.brake_last - wind_brake, 0.0, 1.0)
           apply_brake = int(np.clip(apply_brake * self.params.NIDEC_BRAKE_MAX, 0, self.params.NIDEC_BRAKE_MAX - 1))
@@ -399,7 +423,7 @@ class CarController(CarControllerBase):
     # Send dashboard UI commands. On CAN FD, ACC_HUD is a radar/ADAS look-alike that openpilot only
     # owns when it has disabled the radar (op longitudinal); in stock ACC the real system sends it and
     # the non-long safety config doesn't allowlist it.
-    if (self.CP.carFingerprint in HONDA_BOSCH_CANFD) and CS.hud_tick and self.CP.openpilotLongitudinalControl:
+    if (self.CP.carFingerprint in HONDA_BOSCH_CANFD) and CS.hud_tick and self.CP.openpilotLongitudinalControl and not CS.stock_acc_alive:
         pcm_accel = actuators.accel
         can_sends.append(hondacan.create_acc_hud(self.packer, self.CAN.pt, self.CP, CC.enabled, pcm_speed, pcm_accel,
                                                  hud_control, hud_v_cruise, CS.is_metric, CS.acc_hud, speed_control,
@@ -457,7 +481,8 @@ class CarController(CarControllerBase):
     # (and are only allowed by panda safety) when the radar is disabled, i.e. openpilot longitudinal;
     # in stock ACC the real radar still owns LANE_PATH/HUD_OBJECTS, so don't author them.
     if ((self.frame % 2 == 0 and self.CP.carFingerprint in HONDA_BOSCH_RADARLESS) or
-        (CS.radar_50hz_tick and self.CP.carFingerprint in HONDA_BOSCH_CANFD and self.CP.openpilotLongitudinalControl)):
+        (CS.radar_50hz_tick and self.CP.carFingerprint in HONDA_BOSCH_CANFD and self.CP.openpilotLongitudinalControl
+         and not CS.stock_acc_alive)):
       lead = hud_objects.lead_from_model(self.model, CS.out.vEgo)
       lead_d = lead.dRel if lead.status else 0.0  # extend the lane out to the lead (0 = no lead)
       self.dash_lane = self.lane_path_fitter.update(self.model, CS.out.vEgo, lead_d)
@@ -519,7 +544,7 @@ class CarController(CarControllerBase):
         cruise_setting = CS.cruise_setting
 
       can_sends.append(hondacan.spam_buttons_command(self.packer, self.CAN, CS.cruise_buttons, cruise_setting,
-                                                     self.CP.carFingerprint, bus=self.CAN.camera))
+                                                     CS.scm_ambient_light, self.CP.carFingerprint, bus=self.CAN.camera))
 
     new_actuators = actuators.as_builder()
     new_actuators.speed = self.speed

--- a/opendbc/car/honda/carstate.py
+++ b/opendbc/car/honda/carstate.py
@@ -66,6 +66,17 @@ class CarState(CarStateBase):
     self.radar_50hz_tick_counter = 0
     self.radar_50hz_tick = False
 
+    self.scm_ambient_light = 0
+    # CAN FD deferred radar disable (see carcontroller): the stock radar is assumed alive until it has
+    # been silent for a few frames, and the relay is detected open once the camera's STEERING_CONTROL
+    # stops being physically visible on the PT bus.
+    self.stock_acc_counter = 0
+    self.stock_acc_alive = False
+    self.camera_steer_counter = 0
+    self.camera_steer_seen = False
+    self.canfd_frames = 0
+    self.canfd_relay_open = False
+
     # Only radarless cars have a camera that emits HUD_OBJECTS to poll for secondary vehicle locations.
     # On CAN FD cars the radar owned HUD_OBJECTS and it is disabled, so there is nothing to track.
     self.hud_object_tracker = HudObjectTracker() if CP.carFingerprint in HONDA_BOSCH_RADARLESS else None
@@ -89,6 +100,10 @@ class CarState(CarStateBase):
     prev_cruise_setting = self.cruise_setting
     self.cruise_setting = cp.vl["SCM_BUTTONS"]["CRUISE_SETTING"]
     self.cruise_buttons = cp.vl["SCM_BUTTONS"]["CRUISE_BUTTONS"]
+    if self.CP.carFingerprint in (HONDA_BOSCH_RADARLESS | HONDA_BOSCH_CANFD):
+      # The camera consumes SCM_BUTTONS content beyond the buttons (losing/zeroing this byte raises an
+      # adaptive high beam error), so it must be echoed on frames sent in the SCM's place.
+      self.scm_ambient_light = cp.vl["SCM_BUTTONS"]["AMBIENT_LIGHT_MAYBE"]
 
     # used for car hud message
     # TODO: find CAR_SPEED for HONDA_ODYSSEY_TWN or use ACC_HUD w/ detection
@@ -312,6 +327,26 @@ class CarState(CarStateBase):
       else:
         self.radar_50hz_tick_counter += 1
       self.radar_50hz_tick = (self.radar_50hz_tick_counter == 1)
+
+      # Deferred radar disable (see carcontroller). The stock radar transmits ACC_CONTROL every 2
+      # frames, so 4 missed frames means it has been silenced; assume alive until then so the
+      # replacement stream never overlaps it.
+      self.canfd_frames += 1
+      if len(cp.vl_all.get("ACC_CONTROL", {}).get("COUNTER", [])) > 0:
+        self.stock_acc_counter = 0
+      else:
+        self.stock_acc_counter += 1
+      self.stock_acc_alive = self.stock_acc_counter < 4
+
+      # While the comma relay is closed the camera's STEERING_CONTROL is physically visible on the PT
+      # bus; when the relay opens it disappears (openpilot's own 0xE4 TX is not parsed as RX). As a
+      # fallback, assume the relay is open after 5 s of controls in case the camera was never seen.
+      if len(cp.vl_all.get("STEERING_CONTROL", {}).get("COUNTER", [])) > 0:
+        self.camera_steer_counter = 0
+        self.camera_steer_seen = True
+      else:
+        self.camera_steer_counter += 1
+      self.canfd_relay_open = (self.camera_steer_seen and self.camera_steer_counter >= 5) or self.canfd_frames >= 500
     else:
       self.supp_tick = False
       self.hud_tick = False
@@ -335,8 +370,14 @@ class CarState(CarStateBase):
     return ret
 
   def get_can_parsers(self, CP):
+    pt_messages = []
+    if CP.carFingerprint in HONDA_BOSCH_CANFD:
+      # Radar-alive and relay-open detection for the deferred radar disable (see carcontroller).
+      # Both messages intentionally go silent (the radar is disabled, the camera ends up behind the
+      # open relay), so subscribe with NaN frequency to skip the alive/timeout checks.
+      pt_messages += [("ACC_CONTROL", float('nan')), ("STEERING_CONTROL", float('nan'))]
     parsers = {
-      Bus.pt: CANParser(DBC[CP.carFingerprint][Bus.pt], [], CanBus(CP).pt),
+      Bus.pt: CANParser(DBC[CP.carFingerprint][Bus.pt], pt_messages, CanBus(CP).pt),
       Bus.cam: CANParser(DBC[CP.carFingerprint][Bus.pt], [], CanBus(CP).camera),
     }
     if CP.enableBsm:

--- a/opendbc/car/honda/hondacan.py
+++ b/opendbc/car/honda/hondacan.py
@@ -248,10 +248,12 @@ def create_legacy_brake_command(packer, bus):
   return packer.make_can_msg("LEGACY_BRAKE_COMMAND", bus, {})
 
 
-def spam_buttons_command(packer, CAN, cruise_button, cruise_setting, car_fingerprint, bus=None):
+def spam_buttons_command(packer, CAN, cruise_button, cruise_setting, ambient_light, car_fingerprint, bus=None):
   values = {
     'CRUISE_BUTTONS': cruise_button,
     'CRUISE_SETTING': cruise_setting,
+    # the camera consumes this byte too (adaptive high beam); echo the SCM's live value
+    'AMBIENT_LIGHT_MAYBE': ambient_light,
   }
   if bus is None:
     # send buttons to camera on radarless (camera does ACC) cars

--- a/opendbc/car/honda/interface.py
+++ b/opendbc/car/honda/interface.py
@@ -2,7 +2,7 @@
 import numpy as np
 from opendbc.car import get_safety_config, structs, uds
 from opendbc.car.common.conversions import Conversions as CV
-from opendbc.car.disable_ecu import disable_ecu, clear_all_dtcs
+from opendbc.car.disable_ecu import disable_ecu, clear_all_dtcs, clear_ecu_dtcs
 from opendbc.car.honda.hondacan import CanBus
 from opendbc.car.honda.values import CarControllerParams, HondaFlags, CAR, HONDA_BOSCH, HONDA_BOSCH_CANFD, \
                                                  HONDA_NIDEC_ALT_SCM_MESSAGES, HONDA_BOSCH_RADARLESS, HondaSafetyFlags
@@ -331,28 +331,31 @@ class CarInterface(CarInterfaceBase):
   @staticmethod
   def init(CP, can_recv, can_send, communication_control=None):
     if CP.carFingerprint in (HONDA_BOSCH - HONDA_BOSCH_RADARLESS) and CP.openpilotLongitudinalControl:
-      # 0x80 silences response
-      clear_dtc = False
-      if communication_control is None:
-        communication_control = bytes([uds.SERVICE_TYPE.COMMUNICATION_CONTROL, 0x80 | uds.CONTROL_TYPE.DISABLE_RX_DISABLE_TX,
-                                       uds.MESSAGE_TYPE.NORMAL_AND_NETWORK_MANAGEMENT])
-        # The CAN FD radar stores DTCs while disabled; clear them on disable so stale codes from a
-        # previous drive don't fault the brake module at startup.
-        clear_dtc = CP.carFingerprint in HONDA_BOSCH_CANFD
-      if clear_dtc:
-        # The brake module (VSA) latches a radar lost-communication DTC when the radar goes silent for
-        # more than ~0.1 s at cutover. The DTC matures over trips (Honda two-trip detection): once it is
-        # confirmed from a previous drive, the very next comm-loss detection trips BRAKE_MODULE.CRUISE_FAULT
-        # (accFaulted) ~0.16 s after the radar is silenced, and it stays set for the whole drive. Only a
-        # drive with the radar alive (openpilot longitudinal off) heals it.
-        # Broadcast-clear stored DTCs on all ECUs (powertrain and camera buses) BEFORE silencing the radar:
-        # the maturation counter is reset every drive, so this drive's comm-loss stays a first-trip pending
-        # code that never faults. Clearing must happen before the disable because the fault trips ~0.16 s
-        # after radar silence while a DTC clear can take an ECU several hundred ms to process.
-        # NOTE: init() runs while the panda is still in the ELM327 safety mode, which allows the 29-bit
-        # functional diagnostic address on every bus, so the car safety mode needs no TX allowlist entry.
+      if communication_control is None and CP.carFingerprint in HONDA_BOSCH_CANFD:
+        # CAN FD: only clear DTCs here; the radar silencing itself is deferred to CarController until
+        # the comma relay is confirmed open. init() runs while the panda is still in the ELM327 safety
+        # mode, and silencing the radar from here raced the safety-mode switch: openpilot's replacement
+        # ACC_CONTROL stream was blocked until the switch landed, and whenever that took longer than
+        # ~110 ms the brake module (VSA) latched CRUISE_FAULT (accFaulted) for the entire drive.
+        #
+        # The brake module latches a radar lost-communication DTC when the radar goes silent for more
+        # than ~0.1 s at cutover, and the DTC matures over trips (Honda two-trip detection): once it is
+        # confirmed from a previous drive, the very next comm-loss detection trips
+        # BRAKE_MODULE.CRUISE_FAULT ~0.16 s after the radar is silenced. Broadcast-clear stored DTCs on
+        # all ECUs (powertrain and camera buses) every drive so the maturation counter is reset, and
+        # clear the radar's own stored DTCs so codes accumulated while it was disabled don't re-fault a
+        # later drive. Clearing must precede the radar silence because a DTC clear can take an ECU
+        # several hundred ms to process.
+        # NOTE: ELM327 safety mode allows the 29-bit functional diagnostic address on every bus, so the
+        # broadcast needs no TX allowlist entry in the car safety mode.
         clear_all_dtcs(can_send, [CanBus(CP).pt, CanBus(CP).camera])
-      disable_ecu(can_recv, can_send, bus=CanBus(CP).pt, addr=0x18DAB0F1, com_cont_req=communication_control, clear_dtc=clear_dtc)
+        clear_ecu_dtcs(can_recv, can_send, bus=CanBus(CP).pt, addr=0x18DAB0F1)
+      else:
+        # 0x80 silences response
+        if communication_control is None:
+          communication_control = bytes([uds.SERVICE_TYPE.COMMUNICATION_CONTROL, 0x80 | uds.CONTROL_TYPE.DISABLE_RX_DISABLE_TX,
+                                         uds.MESSAGE_TYPE.NORMAL_AND_NETWORK_MANAGEMENT])
+        disable_ecu(can_recv, can_send, bus=CanBus(CP).pt, addr=0x18DAB0F1, com_cont_req=communication_control)
 
   @staticmethod
   def deinit(CP, can_recv, can_send):

--- a/opendbc/dbc/generator/honda/_bosch_2018.dbc
+++ b/opendbc/dbc/generator/honda/_bosch_2018.dbc
@@ -128,6 +128,7 @@ BO_ 586 ADJACENT_RIGHT_LANE_LINE_2: 8 CAM
 BO_ 662 SCM_BUTTONS: 4 SCM
  SG_ CRUISE_BUTTONS : 7|3@0+ (1,0) [0|7] "" EON
  SG_ CRUISE_SETTING : 3|2@0+ (1,0) [0|3] "" EON
+ SG_ AMBIENT_LIGHT_MAYBE : 23|8@0+ (1,0) [0|255] "" EON
  SG_ COUNTER : 29|2@0+ (1,0) [0|3] "" EON
  SG_ CHECKSUM : 27|4@0+ (1,0) [0|15] "" EON
 
@@ -205,6 +206,7 @@ BO_ 13275 LKAS_HUD_B: 8 ADAS
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
 
 CM_ SG_ 228 DRIVER_OVERRIDE "Appears to acknowledge STEER_STATUS.NO_TORQUE_ALERT_1";
+CM_ SG_ 662 AMBIENT_LIGHT_MAYBE "Slow-moving sensor value (possibly the ambient light input for adaptive high beam), undecoded. The camera consumes SCM_BUTTONS content beyond the buttons, so frames sent in its place must echo this byte";
 CM_ SG_ 576 LINE_DISTANCE_VISIBLE "Length of line visible, undecoded";
 CM_ SG_ 577 LINE_FAR_EDGE_POSITION "Appears to be a measure of line thickness, indicates location of the portion of the line furthest from the car, undecoded";
 CM_ SG_ 577 LINE_PARAMETER "Unclear if this is low quality line curvature rate or if this is something else, but it is correlated with line curvature, undecoded";

--- a/opendbc/safety/modes/honda.h
+++ b/opendbc/safety/modes/honda.h
@@ -34,6 +34,9 @@ static bool honda_nidec_hybrid = false;
 static bool honda_bosch_long = false;
 static bool honda_bosch_radarless = false;
 static bool honda_bosch_canfd = false;
+// counts down on each stock SCM_BUTTONS rx, topped up on each OP SCM_BUTTONS tx to the camera:
+// the stock buttons are only blocked from forwarding while OP's replacement stream is actually flowing
+static int honda_op_buttons_fresh = 0;
 typedef enum {HONDA_NIDEC, HONDA_BOSCH} HondaHw;
 static HondaHw honda_hw = HONDA_NIDEC;
 
@@ -106,6 +109,11 @@ static void honda_rx_hook(const CANPacket_t *msg) {
   // state machine to enter and exit controls for button enabling
   // 0x1A6 for the ILX, 0x296 for the Civic Touring
   if (((msg->addr == 0x1A6U) || (msg->addr == 0x296U)) && (msg->bus == pt_bus)) {
+    // stock buttons act as the clock for the OP button takeover freshness (see honda_bosch_fwd_hook)
+    if (honda_op_buttons_fresh > 0) {
+      honda_op_buttons_fresh--;
+    }
+
     int button = (msg->data[0] & 0xE0U) >> 5;
 
     // enter controls on the falling edge of set or resume
@@ -278,9 +286,29 @@ static bool honda_tx_hook(const CANPacket_t *msg) {
     }
   }
 
+  // OP is streaming SCM_BUTTONS to the camera: block the stock buttons from forwarding while this
+  // stream stays fresh (see honda_bosch_fwd_hook). Topped up here so the block fails safe: if OP
+  // stops sending (e.g. it refuses to engage while the panda's button state machine allowed controls),
+  // the stock buttons resume forwarding within ~10 button frames (~0.4 s).
+  if (tx && (msg->addr == 0x296U) && (msg->bus == 2U)) {
+    honda_op_buttons_fresh = 10;
+  }
+
   // Only tester present ("\x02\x3E\x80\x00\x00\x00\x00\x00") allowed on diagnostics address
+  // On CAN FD the radar is silenced from CarController once the comma relay is open (rather than from
+  // CarInterface.init() under the ELM327 mode, which raced the safety-mode switch and could leave the
+  // brake module without ACC_CONTROL long enough to latch CRUISE_FAULT), so additionally allow exactly
+  // the extended-diagnostic-session request and the suppressed-response CommunicationControl
+  // disableRxAndTx request. The corresponding enable stays blocked: re-enabling the radar into OP's
+  // ACC_CONTROL stream would double up control messages while driving.
   if (msg->addr == 0x18DAB0F1U) {
-    if ((GET_BYTES(msg, 0, 4) != 0x00803E02U) || (GET_BYTES(msg, 4, 4) != 0x0U)) {
+    const uint32_t first_bytes = GET_BYTES(msg, 0, 4);
+    bool allowed = (first_bytes == 0x00803E02U);
+    if (honda_bosch_canfd) {
+      allowed = allowed || (first_bytes == 0x00031002U);  // 02 10 03: extended diagnostic session
+      allowed = allowed || (first_bytes == 0x03832803U);  // 03 28 83 03: CommunicationControl disable rx/tx
+    }
+    if (!allowed || (GET_BYTES(msg, 4, 4) != 0x0U)) {
       tx = false;
     }
   }
@@ -306,6 +334,7 @@ static safety_config honda_nidec_init(uint16_t param) {
   honda_bosch_long = false;
   honda_bosch_radarless = false;
   honda_bosch_canfd = false;
+  honda_op_buttons_fresh = 0;
 
   safety_config ret;
 
@@ -394,6 +423,7 @@ static safety_config honda_bosch_init(uint16_t param) {
 
   honda_hw = HONDA_BOSCH;
   honda_brake_switch_prev = false;
+  honda_op_buttons_fresh = 0;
   honda_bosch_radarless = GET_FLAG(param, HONDA_PARAM_RADARLESS);
   honda_bosch_canfd = GET_FLAG(param, HONDA_PARAM_BOSCH_CANFD);
   // Checking for alternate brake override from safety parameter
@@ -469,8 +499,18 @@ static bool honda_bosch_fwd_hook(int bus_num, int addr) {
 
   // On radarless and CAN FD, OP takes over SCM_BUTTONS (0x296) towards the camera when engaged, to
   // auto-disable stock LKAS and block the driver's LKAS button (the touch-steering-wheel timer would
-  // otherwise force a disengagement). Only forward the stock buttons when disengaged.
-  if ((honda_bosch_radarless || honda_bosch_canfd) && controls_allowed && (bus_num == 0) && (addr == 0x296)) {
+  // otherwise force a disengagement). Only block the stock buttons while OP's replacement stream is
+  // actually flowing (honda_op_buttons_fresh): the camera needs SCM_BUTTONS content beyond the buttons
+  // (it raises an adaptive high beam error when the message goes missing), so a bare controls_allowed
+  // gate would starve it whenever the panda allows controls but OP refuses to engage.
+  if ((honda_bosch_radarless || honda_bosch_canfd) && controls_allowed && (honda_op_buttons_fresh > 0) &&
+      (bus_num == 0) && (addr == 0x296)) {
+    block_msg = true;
+  }
+
+  // CAN FD: the radar disable handshake happens after the relay is open, so block the radar's UDS
+  // responses from forwarding to the camera (the camera doesn't need them)
+  if (honda_bosch_canfd && (bus_num == 0) && (addr == 0x18DAF1B0)) {
     block_msg = true;
   }
 

--- a/opendbc/safety/tests/test_honda.py
+++ b/opendbc/safety/tests/test_honda.py
@@ -498,6 +498,12 @@ class TestHondaBoschLongSafety(HondaButtonEnableBase, TestHondaBoschSafetyBase):
     not_tester_present = libsafety_py.make_CANPacket(0x18DAB0F1, self.PT_BUS, b"\x03\xAA\xAA\x00\x00\x00\x00\x00")
     self.assertFalse(self._tx(not_tester_present))
 
+    # the radar disable requests are only allowed on CAN FD
+    ext_diag = libsafety_py.make_CANPacket(0x18DAB0F1, self.PT_BUS, b"\x02\x10\x03\x00\x00\x00\x00\x00")
+    self.assertFalse(self._tx(ext_diag))
+    comm_control_disable = libsafety_py.make_CANPacket(0x18DAB0F1, self.PT_BUS, b"\x03\x28\x83\x03\x00\x00\x00\x00")
+    self.assertFalse(self._tx(comm_control_disable))
+
   def test_gas_safety_check(self):
     for controls_allowed in [True, False]:
       for gas in np.arange(self.NO_GAS, self.MAX_GAS + 2000, 100):
@@ -531,12 +537,31 @@ class TestHondaBoschRadarlessSafetyBase(TestHondaBoschSafetyBase):
     self.safety = libsafety_py.libsafety
 
   def test_buttons_fwd(self):
-    # SCM_BUTTONS (0x296) forwards only when disengaged: while engaged, OP takes over
-    # the buttons towards the camera to auto-disable stock LKAS and block the LKAS button
+    # SCM_BUTTONS (0x296) forwards to the camera unless OP's replacement button stream is flowing
+    # (engaged + a recent OP SCM_BUTTONS tx on the camera bus). The camera needs the message content
+    # beyond the buttons, so the block fails safe back to forwarding when OP stops sending (e.g. it
+    # refuses to engage even though the panda's button state machine allowed controls).
+    self.safety.set_controls_allowed(False)
+    self.assertEqual(2, self.safety.safety_fwd_hook(0, 0x296))
+
+    # engaged but OP not sending buttons: keep forwarding
+    self.safety.set_controls_allowed(True)
+    self.assertEqual(2, self.safety.safety_fwd_hook(0, 0x296))
+
+    # OP button stream flowing: block the stock buttons
+    self.assertTrue(self._tx(self._button_msg(Btn.NONE, bus=2)))
+    self.assertEqual(-1, self.safety.safety_fwd_hook(0, 0x296))
+
+    # never blocked while disengaged
     self.safety.set_controls_allowed(False)
     self.assertEqual(2, self.safety.safety_fwd_hook(0, 0x296))
     self.safety.set_controls_allowed(True)
     self.assertEqual(-1, self.safety.safety_fwd_hook(0, 0x296))
+
+    # freshness decays after 10 stock button frames without an OP tx
+    for _ in range(10):
+      self._rx(self._button_msg(Btn.NONE, main_on=True))
+    self.assertEqual(2, self.safety.safety_fwd_hook(0, 0x296))
 
 
 class TestHondaBoschRadarlessSafety(HondaPcmEnableBase, TestHondaBoschRadarlessSafetyBase):
@@ -601,12 +626,29 @@ class TestHondaBoschCANFDSafetyBase(TestHondaBoschSafetyBase):
     self.safety = libsafety_py.libsafety
 
   def test_buttons_fwd(self):
-    # SCM_BUTTONS (0x296) forwards only when disengaged: while engaged, OP takes over
-    # the buttons towards the camera to auto-disable stock LKAS and block the LKAS button
+    # SCM_BUTTONS (0x296) forwards to the camera unless OP's replacement button stream is flowing
+    # (engaged + a recent OP SCM_BUTTONS tx on the camera bus); see the radarless variant of this test
+    self.safety.set_controls_allowed(True)
+    self.assertEqual(2, self.safety.safety_fwd_hook(0, 0x296))
+
+    self.assertTrue(self._tx(self._button_msg(Btn.NONE, bus=2)))
+    self.assertEqual(-1, self.safety.safety_fwd_hook(0, 0x296))
+
     self.safety.set_controls_allowed(False)
     self.assertEqual(2, self.safety.safety_fwd_hook(0, 0x296))
+
     self.safety.set_controls_allowed(True)
-    self.assertEqual(-1, self.safety.safety_fwd_hook(0, 0x296))
+    for _ in range(10):
+      self._rx(self._button_msg(Btn.NONE, main_on=True))
+    self.assertEqual(2, self.safety.safety_fwd_hook(0, 0x296))
+
+  def test_radar_diag_response_fwd(self):
+    # the radar's UDS responses (0x18DAF1B0) never forward to the camera: the radar disable handshake
+    # happens after the relay is open on CAN FD
+    self.safety.set_controls_allowed(False)
+    self.assertEqual(-1, self.safety.safety_fwd_hook(0, 0x18DAF1B0))
+    self.safety.set_controls_allowed(True)
+    self.assertEqual(-1, self.safety.safety_fwd_hook(0, 0x18DAF1B0))
 
   def test_buttons_tx_camera_bus(self):
     # Buttons to the camera (bus 2): cancel-only while disengaged, any button while engaged
@@ -659,6 +701,24 @@ class TestHondaBoschCANFDLongSafety(TestHondaBoschLongSafety, TestHondaBoschCANF
     super().setUp()
     self.safety.set_safety_hooks(CarParams.SafetyModel.hondaBosch, HondaSafetyFlags.BOSCH_CANFD | HondaSafetyFlags.BOSCH_LONG)
     self.safety.init_tests()
+
+  def test_diagnostics(self):
+    # CAN FD silences the radar from CarController after the relay opens, so exactly the extended
+    # diagnostic session and the suppressed-response CommunicationControl disable are allowed too
+    tester_present = libsafety_py.make_CANPacket(0x18DAB0F1, self.PT_BUS, b"\x02\x3E\x80\x00\x00\x00\x00\x00")
+    self.assertTrue(self._tx(tester_present))
+    ext_diag = libsafety_py.make_CANPacket(0x18DAB0F1, self.PT_BUS, b"\x02\x10\x03\x00\x00\x00\x00\x00")
+    self.assertTrue(self._tx(ext_diag))
+    comm_control_disable = libsafety_py.make_CANPacket(0x18DAB0F1, self.PT_BUS, b"\x03\x28\x83\x03\x00\x00\x00\x00")
+    self.assertTrue(self._tx(comm_control_disable))
+
+    # anything else stays blocked, including re-enabling the radar and non-zero trailing bytes
+    comm_control_enable = libsafety_py.make_CANPacket(0x18DAB0F1, self.PT_BUS, b"\x03\x28\x80\x03\x00\x00\x00\x00")
+    self.assertFalse(self._tx(comm_control_enable))
+    not_tester_present = libsafety_py.make_CANPacket(0x18DAB0F1, self.PT_BUS, b"\x03\xAA\xAA\x00\x00\x00\x00\x00")
+    self.assertFalse(self._tx(not_tester_present))
+    trailing_bytes = libsafety_py.make_CANPacket(0x18DAB0F1, self.PT_BUS, b"\x02\x10\x03\x00\x00\x00\x00\x01")
+    self.assertFalse(self._tx(trailing_bytes))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the engagement failures in route `ad9840558640c31d/0000004c--06caa68c3c`. Log forensics found two problems; #617 itself was not the cause of the first, but it caused the second.

## 1. Startup CRUISE_FAULT: whole drive refused engagement (`wrongCarMode`)

- The VSA latched `BRAKE_MODULE.CRUISE_FAULT` 0.15 s after the radar was silenced at startup, and the fork's fault masking then held `cruiseState.available = False` for the entire drive.
- Root cause is a race that #616 could not fully close: `CarInterface.init()` silences the radar while the panda is still in ELM327 mode. openpilot began attempting ACC_CONTROL within 11 ms, but the panda blocked it until the safety-mode switch landed — 130 ms later this drive vs 69 ms in the clean route 4a. The VSA tolerance is ~110 ms, so this was a coin flip on pandad's mode-switch latency.

**Fix — the sequencing change already identified as a follow-up in the project learnings, implemented opendbc-only:**
- `init()` now only clears DTCs (broadcast + the radar's own, via a new `clear_ecu_dtcs()` helper). The radar keeps transmitting.
- CarController detects relay-open (the camera's `STEERING_CONTROL` is physically visible on the PT bus while the relay is closed and disappears when it opens) and only then sends the UDS disable (`10 03`, then suppressed-response `28 83 03`, retried every 0.5 s).
- openpilot's ACC_CONTROL, ACC_HUD, and all radar look-alikes are suppressed while the stock radar is still transmitting (`stock_acc_alive`, 4 missed 50 Hz frames = silent), so the stock radar feeds the brake module — and, via panda forwarding, the camera — right up to the switchover, and the replacement stream starts within a few frames of silence. The handoff gap is now ~40–60 ms regardless of pandad latency.
- Safety: exactly the two payloads `02 10 03` and `03 28 83 03` are additionally allowed on 0x18DAB0F1 for CAN FD (the re-enable `03 28 80 03` stays blocked), and the radar's UDS responses (0x18DAF1B0) are blocked from forwarding to the camera (PR #598 port).
- Side benefit: the camera is fed with zero gap through cutover, which per the learnings should also address the latched RDM_PROBLEM/LKAS_PROBLEM staleness fault.

## 2. New adaptive-high-beam error on every engage attempt (#617 defect)

- Verified in seg 25: the SET press set panda `controls_allowed=True`, which started blocking SCM_BUTTONS forwarding to the camera — but openpilot refused to engage (masked fault) and never sent the replacement stream, starving the camera for 2+ s per attempt.
- The forward block is now additionally gated on openpilot's replacement stream actually flowing: each 0x296 bus-2 TX tops up a freshness counter that decays over ~10 stock button frames (~0.4 s), so the block fails safe back to forwarding.
- SCM_BUTTONS byte 2 also carries a live sensor value (constant 0x82 in some drives, varying 0x5c–0x61 in route 4a — plausibly the ambient light input for adaptive high beam). Added as `AMBIENT_LIGHT_MAYBE` to the DBC and echoed on every frame openpilot sends in the SCM's place (takeover and cancel/resume spam), so the takeover is byte-faithful.

## Testing

- All 356 Honda safety tests pass (new/updated: freshness-gated `test_buttons_fwd` for radarless + CAN FD, `test_radar_diag_response_fwd`, CAN FD `test_diagnostics` payload gate including blocked re-enable and trailing-byte variants, non-CAN-FD Bosch asserts the disable payloads stay blocked). Toyota/Hyundai/defaults/ELM327 cross-mode suites pass.
- Offline CarController harness: no diagnostics before relay-open; disable sequence at relay-open; zero ACC_CONTROL/look-alike overlap with the live radar; replacement stream starts the frame the radar is considered silent; tester-present resumes after silence; takeover echoes byte 2.
- The real `CarState` class replayed against route 4c's actual CAN stream reproduces the expected detector transitions (`stock_acc_alive` False at 85.642, `relay_open` True at 85.773, ambient byte captured as 0x82) with `can_valid` intact (the new subscriptions use NaN frequency so the intentionally-silent messages skip alive checks).
- All 45 Honda platforms construct parsers and run `CarState.update()` cleanly; `ruff` and `codespell` pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4c6d9f9-419d-4c66-99aa-aaa2ea8525df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4c6d9f9-419d-4c66-99aa-aaa2ea8525df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

