### PR TITLE
Honda: fix radarless test_models CI failures (accFaulted membership, HUD_OBJECTS validity)

### DIFF
--- a/opendbc/car/honda/carstate.py
+++ b/opendbc/car/honda/carstate.py
@@ -168,7 +168,7 @@ class CarState(CarStateBase):
     if self.CP.carFingerprint not in HONDA_BOSCH:
       ret.carFaultedNonCritical = bool(cp_cam.vl["ACC_HUD"]["ACC_PROBLEM"] or cp_cam.vl["LKAS_HUD"]["LKAS_PROBLEM"])
 
-    elif self.CP.carFingerprint in (HONDA_BOSCH_RADARLESS, HONDA_BOSCH_CANFD):
+    elif self.CP.carFingerprint in HONDA_BOSCH_RADARLESS:
       ret.accFaulted = bool(cp.vl["CRUISE_FAULT_STATUS"]["CRUISE_FAULT"])
     else:
       if self.CP.openpilotLongitudinalControl:
@@ -371,14 +371,19 @@ class CarState(CarStateBase):
 
   def get_can_parsers(self, CP):
     pt_messages = []
+    cam_messages = []
     if CP.carFingerprint in HONDA_BOSCH_CANFD:
       # Radar-alive and relay-open detection for the deferred radar disable (see carcontroller).
       # Both messages intentionally go silent (the radar is disabled, the camera ends up behind the
       # open relay), so subscribe with NaN frequency to skip the alive/timeout checks.
       pt_messages += [("ACC_CONTROL", float('nan')), ("STEERING_CONTROL", float('nan'))]
+    if CP.carFingerprint in HONDA_BOSCH_RADARLESS:
+      # HUD_OBJECTS is polled by the HudObjectTracker, but not every radarless camera emits it,
+      # so subscribe with NaN frequency to skip the alive/timeout checks.
+      cam_messages += [("HUD_OBJECTS", float('nan'))]
     parsers = {
       Bus.pt: CANParser(DBC[CP.carFingerprint][Bus.pt], pt_messages, CanBus(CP).pt),
-      Bus.cam: CANParser(DBC[CP.carFingerprint][Bus.pt], [], CanBus(CP).camera),
+      Bus.cam: CANParser(DBC[CP.carFingerprint][Bus.pt], cam_messages, CanBus(CP).camera),
     }
     if CP.enableBsm:
       parsers[Bus.body] = CANParser(DBC[CP.carFingerprint][Bus.body], [], CanBus(CP).radar)

--- a/opendbc/car/honda/hud_objects.py
+++ b/opendbc/car/honda/hud_objects.py
@@ -43,8 +43,8 @@ class HudObjectTracker:
     # to 0-based indices 0-9.
     # Using vl_all to catch any missed frames, though not strictly necessary since update() is called
     # at 100Hz and this signal updates at 50Hz.
-    # Touching vl first registers the message.
-    _ = cp_cam.vl["HUD_OBJECTS"]
+    # The message is subscribed with NaN frequency in get_can_parsers: not every radarless camera
+    # emits it, so it must not gate the parser's validity.
     vla = cp_cam.vl_all["HUD_OBJECTS"]
 
     muxes = vla["MUX"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the `test models` CI failures in [run 30178585300](https://github.com/mvl-boston/opendbc/actions/runs/30178585300) (jobs 0, 2, 3), which have been failing since the CAN-FD radar timer work landed. All failing cars are radarless Bosch Hondas, hit by two independent regressions:

### 1. `mainOn` panda-safety mismatches (ACURA_ADX, HONDA_HRV_3G)

`add LKAS_HUD to canfd` (e6d8a483d) rewrote the radarless `accFaulted` branch in `carstate.py` as:

```python
elif self.CP.carFingerprint in (HONDA_BOSCH_RADARLESS, HONDA_BOSCH_CANFD):
```

That's a tuple containing two *sets*, so the membership test compares the fingerprint against the sets themselves and never matches. Radarless cars fell through to the legacy Bosch branch, which under openpilot longitudinal reads `STANDSTILL` `BRAKE_ERROR_1/2` — bits that decode as constantly set on these cars. Internal `accFaulted` stayed true for the whole drive, the initial-fault masking held `cruiseState.available` low, and panda safety (which tracks `SCM_FEEDBACK.MAIN_ON` correctly) disagreed on every frame (`{'mainOn': 6000}`).

Fixed by restoring the radarless-only set membership. CAN FD keeps using the `BRAKE_MODULE`/brake-error path as designed by the later deferred-radar-disable work — its DBC has no `CRUISE_FAULT_STATUS`, so including it in this branch would have raised anyway.

### 2. `can_invalid_cnt` failures (HONDA_CITY_7G, HONDA_FIT_4G, two HONDA_HRV_3G routes)

`HudObjectTracker.update()` touched `cp_cam.vl["HUD_OBJECTS"]` to lazily register the message, which makes it a *checked* message on the camera parser. Not every radarless camera emits HUD_OBJECTS, so on those routes the parser was invalid for the entire drive (`CANParser: 0x6cd5557 HUD_OBJECTS not valid (timeout or missing)`) and `test_car_interface` failed with `can_invalid_cnt` ≈ the full route length.

Fixed by subscribing HUD_OBJECTS explicitly with NaN frequency in `get_can_parsers()` (the same pattern used for `ACC_CONTROL`/`STEERING_CONTROL` on CAN FD), so it never gates parser validity, and dropping the `vl` touch.

## Verification

Replayed the exact `test_models` logic (fingerprinting, warm-up, `CI.update` + `safety_rx_hook` loop, `mainOn`/`can_invalid_cnt` checks) locally against the same CI route segments:

| Car | Route | Failure before | After |
|---|---|---|---|
| ACURA_ADX | `ad9840558640c31d/00000026` | mainOn 6000 | 0 |
| HONDA_HRV_3G | `320098ff6c5e4730/2023-04-13` | mainOn 5999 | 0 |
| HONDA_CITY_7G | `56b2cf1dacdcd033/00000017` | can_invalid 5750 | 0 |
| HONDA_FIT_4G | `f0a3de7786dcc72c/0000001a` | can_invalid 5749 | 0 |
| HONDA_HRV_3G | `147613502316e718/00000001` | can_invalid 5748 | 0 |
| HONDA_HRV_3G | `1e4baee1aa2687a0/00000001` | can_invalid 5749 | 0 |

Regression-checked previously green routes (HONDA_CIVIC_2022, HONDA_CRV_6G, HONDA_ACCORD_11G) — all still clean, and the `HudObjectTracker` still ingests HUD_OBJECTS on cars whose camera emits it. `ruff check`, `opendbc/car/tests` (741 tests), and `opendbc.safety.tests.test_honda` (356 tests) all pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9105ce6c-f217-43f5-9beb-2565e695d2c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9105ce6c-f217-43f5-9beb-2565e695d2c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

