### PR TITLE
safety: restore 10 Hz minimum RX-check frequency guard

### DIFF
--- a/opendbc/safety/safety.h
+++ b/opendbc/safety/safety.h
@@ -328,7 +328,7 @@ void safety_tick(const safety_config *cfg) {
       }
 
       // enforce minimum frequency for safety-relevant messages
-      bool frequency_invalid = frequency < 1U;
+      bool frequency_invalid = frequency < 10U;
       if (lagging || frequency_invalid || !is_msg_valid(cfg->rx_checks, i)) {
         rx_checks_invalid = true;
         controls_allowed = false;


### PR DESCRIPTION
Reverts 14e144a. No RX check on this branch (or upstream) is configured
below 10 Hz -- the CAN FD tick references are parsed in carstate, not in
safety -- so the relaxed guard gates nothing, while weakening two
protections: the upstream minimum-frequency floor for safety-relevant
messages, and the lagging threshold (max(10*timestep, 1s)), which would
allow a 1 Hz-configured message a 10 s staleness budget