### PR TITLE
Honda CAN FD: match the stock lane-path curvature (lanes rendered ~5x too flat)

### DIFF
--- a/opendbc/car/honda/hud_objects.py
+++ b/opendbc/car/honda/hud_objects.py
@@ -2,6 +2,7 @@ import math
 from dataclasses import dataclass
 
 from opendbc.can.parser import CANParser
+from opendbc.car.honda import lane_path
 
 # HUD_OBJECTS represents the moving car icons on the dash.
 # The message is multiplexed. Mux values (1-10, 17-26, 33-42, 49-58) map to the same 10 slots.
@@ -277,14 +278,17 @@ class HudObjectAuthor:
     stock_lead_id = stock_lead.object_id if stock_lead is not None else None
     lead_id = self._lead_object_id(lead.status, op_id, stock_lead_id, in_use)
 
-    d_rel, y_rel = self._smoother.update(lead.dRel, LAT_SCALE * lead.yRel, lead.vRel, lead_id, now)
+    # scale the lateral by the lane-gain correction at the lead's distance so the marker tracks the
+    # lane rendering (LAT_SCALE was tuned against the previous, flatter lane gain law)
+    lat_scale = LAT_SCALE * lane_path.curve_boost(lead.dRel)
+    d_rel, y_rel = self._smoother.update(lead.dRel, lat_scale * lead.yRel, lead.vRel, lead_id, now)
 
     slot = (mux - 1) % 16
     if slot == 0 and lead.status:
       track = {"d_rel": d_rel, "y_rel": y_rel, "object_id": lead_id, "is_lead_car": 1,
                "car_type": stock_lead.car_type if stock_lead is not None else CAR_TYPE_CAR,
                # disengaged -> no camera rotation; calculate one from the lead's lateral
-               "rotation": stock_lead.rotation if stock_lead is not None else lead_rotation(y_rel / LAT_SCALE)}
+               "rotation": stock_lead.rotation if stock_lead is not None else lead_rotation(y_rel / lat_scale)}
     # forward slots 1-9 and slot 0 when not a lead
     else:
       st = tracks[slot] if (tracks and slot < len(tracks)) else None

--- a/opendbc/car/honda/lane_path.py
+++ b/opendbc/car/honda/lane_path.py
@@ -22,7 +22,25 @@ OFFSET_VALID_MAX = 2046    # clamp real offsets below the sentinel
 D_NEAR = 2.0
 D_MAX = 100.0
 LOOKAHEAD = np.linspace(D_NEAR, D_MAX, NUM_PTS)               # look-ahead distance of each offset
-GAIN = 6.27 + 0.0106 * LOOKAHEAD + 0.000354 * LOOKAHEAD ** 2  # raw units per meter of lateral, fit to the stock encoding
+# raw units per meter of lateral. Fit per look-ahead index by regressing the stock radar's raw
+# offsets against modelV2's lane-center lateral over the same drive (factory ACC lanes route
+# 3792d010590cb83a|00000107, 187 paired sweeps, lane-line probs >= 0.4): the stock encoding uses
+# ~29-37 raw/m over the rendered 2-55 m, ~4.6-5.1x the previous law, which is why openpilot's lanes
+# rendered noticeably flatter than factory. Correlation with the model lateral rises 0.6 -> 0.96
+# with distance; the quadratic below is the correlation-weighted fit of the per-index gains.
+GAIN = 29.3 + 0.243 * LOOKAHEAD - 0.00228 * LOOKAHEAD ** 2
+# previous law, kept for the HUD-lead lateral consistency ratio in curve_boost()
+GAIN_PREV = 6.27 + 0.0106 * LOOKAHEAD + 0.000354 * LOOKAHEAD ** 2
+
+def curve_boost(d: float) -> float:
+  """Ratio of the corrected stock-fit gain law to the previous one at look-ahead distance d.
+
+  The HUD lead marker's LAT_SCALE was tuned on-car against lanes rendered with the previous
+  (too-flat) law; scaling the lead's lateral by this ratio at the lead's distance keeps the
+  marker on the lane now that the lanes carry the full stock curvature."""
+  d = min(max(float(d), D_NEAR), D_MAX)
+  return (29.3 + 0.243 * d - 0.00228 * d ** 2) / (6.27 + 0.0106 * d + 0.000354 * d ** 2)
+
 
 LANE_LINE_ON = 3            # LEFT_LANE / RIGHT_LANE shown value
 LANE_LENGTH_MAX_VALUE = 33  # full dash reach (have not seen/tested higher)


### PR DESCRIPTION
The dash lanes drew noticeably straighter than factory. Regressing the
stock radar's raw LANE_PATH offsets against modelV2's lane-center
lateral at the same instants (factory ACC lanes route
3792d010590cb83a|00000107, 187 paired sweeps, per look-ahead index)
shows the stock encoding uses ~29-37 raw units per meter over the
rendered 2-55 m -- roughly 4.6-5.1x the previous GAIN law -- with
correlation to the model lateral rising from 0.6 (near, small laterals)
to 0.96 at 55 m. Replace GAIN with the correlation-weighted quadratic
fit of the per-index gains.

Keep the HUD lead marker on the lane: LAT_SCALE (0.35) was tuned on-car
against the old flatter lanes, so scale the lead's lateral by
curve_boost(dRel) -- the new/old gain ratio at the lead's distance --
before smoothing, and derive the fallback rotation from the same scale.

12-bit headroom is unaffected: a hard 5 m lateral at 50 m encodes to
~180 of +/-2046.

Follow-up: LAT_SCALE * curve_boost lands near ~1.7x true meters at
typical lead distances; a one-shot on-car check may simplify the lead
lateral to a single constant