### PR TITLE
Honda CAN FD: stop HUD lead marker flapping and same-id teleports

### DIFF
--- a/opendbc/car/honda/hud_objects.py
+++ b/opendbc/car/honda/hud_objects.py
@@ -182,7 +182,9 @@ def lead_rotation(lateral_left_m: float) -> int:
   return -magnitude if lateral_left_m > 0 else magnitude
 
 
-LEAD_PROB_ON = 0.5   # modelV2 leadsV3 prob to treat a lead as present
+LEAD_PROB_ON = 0.5    # modelV2 leadsV3 prob to start rendering a lead
+LEAD_PROB_OFF = 0.35  # ...and to keep rendering it (hysteresis against threshold flapping)
+LEAD_HOLD_S = 0.6     # s: bridge a dropped lead briefly so single-frame prob dips don't blink the marker
 
 
 @dataclass
@@ -192,6 +194,7 @@ class ModelLead:
   dRel: float
   yRel: float   # +left
   vRel: float
+  prob: float = 0.0   # model lead prob; carried so the author can apply on/off hysteresis
 
 
 def lead_from_model(model, v_ego):
@@ -202,9 +205,12 @@ def lead_from_model(model, v_ego):
   if model is None or len(model.leadsV3) == 0:
     return ModelLead(False, 0.0, 0.0, 0.0)
   lead = model.leadsV3[0]
-  if lead.prob < LEAD_PROB_ON or len(lead.x) == 0:
+  if len(lead.x) == 0:
     return ModelLead(False, 0.0, 0.0, 0.0)
-  return ModelLead(True, float(lead.x[0]), -float(lead.y[0]), float(lead.v[0]) - v_ego)
+  # data is populated below LEAD_PROB_ON too (status False): the HUD author's hysteresis keeps an
+  # already-rendered lead alive down to LEAD_PROB_OFF instead of blinking it at the 0.5 threshold
+  return ModelLead(bool(lead.prob >= LEAD_PROB_ON), float(lead.x[0]), -float(lead.y[0]),
+                   float(lead.v[0]) - v_ego, prob=float(lead.prob))
 
 
 def create_hud_object(packer, bus, mux, track):
@@ -247,6 +253,26 @@ class HudObjectAuthor:
     self._smoother = LeadSmoother()
     self._lead_id = 0       # OBJECT_ID currently emitted for OP's lead (0 = none)
     self._prev_op_id = 0    # last LeadObjectId id, to detect a fresh lead / handoff
+    self._lead_on = False   # hysteresis state for the rendered lead
+    self._lead_hold: ModelLead | None = None   # last rendered lead, for the drop-hold bridge
+    self._lead_seen_t = -1e9
+
+  def _gate_lead(self, lead: ModelLead, now: float) -> ModelLead:
+    """On/off hysteresis + short drop-hold for the rendered lead. leadsV3[0].prob hovers around the
+    0.5 threshold in real traffic, which blinked the dash marker at a sub-second cadence the stock
+    radar never produces; render from LEAD_PROB_ON, keep rendering down to LEAD_PROB_OFF, and bridge
+    a full drop for LEAD_HOLD_S (dead-reckoned on vRel) before blanking the slot."""
+    if lead.prob >= (LEAD_PROB_OFF if self._lead_on else LEAD_PROB_ON):
+      self._lead_on = True
+      self._lead_hold = lead
+      self._lead_seen_t = now
+      return lead if lead.status else ModelLead(True, lead.dRel, lead.yRel, lead.vRel, lead.prob)
+    if self._lead_on and self._lead_hold is not None and now - self._lead_seen_t < LEAD_HOLD_S:
+      h = self._lead_hold
+      return ModelLead(True, h.dRel + h.vRel * (now - self._lead_seen_t), h.yRel, h.vRel, h.prob)
+    self._lead_on = False
+    self._lead_hold = None
+    return ModelLead(False, 0.0, 0.0, 0.0)
 
   def _lead_object_id(self, status: bool, op_id: int, stock_lead_id: int | None, in_use: set[int]) -> int:
     """OBJECT_ID to emit for OP's lead: prefer the camera's own lead id, else hold a minted id, re-picking out of
@@ -256,7 +282,15 @@ class HudObjectAuthor:
     elif stock_lead_id is not None:
       self._lead_id = stock_lead_id
     elif self._lead_id == 0 or op_id != self._prev_op_id or self._lead_id in in_use:
-      self._lead_id = next((i for i in range(1, MAX_OBJECT_ID + 1) if i not in in_use), MAX_OBJECT_ID)
+      # advance from the current id instead of picking the lowest free one: with no camera ids in
+      # use (CAN FD, tracks is None) lowest-free always yielded 1, so a handoff to a different car
+      # kept OBJECT_ID 1 and rendered as the same object teleporting -- and the smoother, keyed on
+      # the emitted id, slid between the two cars instead of snapping. A fresh id per handoff
+      # matches the stock radar and makes the snap take effect.
+      nxt = self._lead_id % MAX_OBJECT_ID + 1
+      while nxt in in_use:
+        nxt = nxt % MAX_OBJECT_ID + 1
+      self._lead_id = nxt
     self._prev_op_id = op_id
     return self._lead_id
 
@@ -265,6 +299,7 @@ class HudObjectAuthor:
     LANE_PATH/HUD_OBJECTS multiplexor for this frame. Returns one packed HUD_OBJECTS frame for the slot the mux lands
     on (OP's lead in slot 0, else a forwarded camera adjacent car — including in slot 0 when OP has no lead — else
     inactive). re-ID + smoothing run every tick so their state stays continuous across the non-lead frames."""
+    lead = self._gate_lead(lead, now)
     op_id = self._track_id.update(lead.status, lead.dRel, lead.vRel, now)
     stock_lead, in_use = None, set()
     for t in (tracks or ()):


### PR DESCRIPTION
Route ad9840558640c31d|0000004f rlogs show two stock-divergent behaviors
in the authored HUD_OBJECTS, both correlated with lead-position changes
(everything else checks out clean: LEFT/RIGHT_LANE render gate high
100% of engaged frames, LANE_PATH/HUD_OBJECTS mux in lockstep on every
frame, RADAR_LEAD LANE_PATH_LENGTH within +/-1 of the in-band
terminator matching stock's distribution, no TX gaps > 100 ms):

1. slot 0 blinks: leadsV3[0].prob hovers around the 0.5 threshold in
   traffic, flapping the lead marker on/off at a sub-second cadence
   (e.g. seg 5: 8 empty<->lead transitions in ~19 s) that the stock
   radar never produces. Add on/off hysteresis (0.5 on / 0.35 off) plus
   a 0.6 s dead-reckoned drop-hold before blanking the slot.

2. OBJECT_ID is 1 forever: with no camera ids in use (tracks is None on
   CAN FD) the lowest-free pick always returned 1, so a lead handoff
   rendered as the same object teleporting tens of meters -- and the
   smoother, keyed on the emitted id, slid between the two cars instead
   of snapping. Mint the next id in rotation on a handoff instead,
   matching the stock radar's fresh-id-per-car behavior.

These are the remaining candidates for the dash intermittently hiding
the lane lines around lead changes: nothing in the lane messages
themselves diverges from stock, so the dash reacting to implausible
slot-0 behavior is the suspect. Needs on-car confirmation.

Offline harness: prob flapping 0.38-0.62 produces zero marker
transitions; a 30 m -> 55 m handoff mints a fresh OBJECT_ID and the
rendered distance snaps