### PR TITLE
Honda CAN FD: repair PR #629 merge reconciliation in hud_objects

### DIFF
--- a/opendbc/car/honda/hud_objects.py
+++ b/opendbc/car/honda/hud_objects.py
@@ -211,34 +211,23 @@ class ModelLead:
 def leads_from_model(model, v_ego, n=3):
   """Up to n ModelLeads from modelV2.leadsV3 (index 0 = the lead OP acts on). modelV2's lateral is
   +right, so it is negated to match the dash's +left. v is made relative (v - vEgo) for the
-  smoother's feed-forward. An entry is inactive when missing or below LEAD_PROB_ON."""
+  smoother's feed-forward. Data stays populated below LEAD_PROB_ON too (status False, prob carried):
+  the HUD author's hysteresis keeps an already-rendered lead alive down to LEAD_PROB_OFF instead of
+  blinking it at the 0.5 threshold."""
   out = []
   for i in range(n):
-    if model is None or len(model.leadsV3) <= i:
+    if model is None or len(model.leadsV3) <= i or len(model.leadsV3[i].x) == 0:
       out.append(ModelLead(False, 0.0, 0.0, 0.0))
       continue
     lead = model.leadsV3[i]
-    if lead.prob < LEAD_PROB_ON or len(lead.x) == 0:
-      out.append(ModelLead(False, 0.0, 0.0, 0.0))
-      continue
-    out.append(ModelLead(True, float(lead.x[0]), -float(lead.y[0]), float(lead.v[0]) - v_ego))
+    out.append(ModelLead(bool(lead.prob >= LEAD_PROB_ON), float(lead.x[0]), -float(lead.y[0]),
+                         float(lead.v[0]) - v_ego, prob=float(lead.prob)))
   return out
 
 
 def lead_from_model(model, v_ego):
-  """OP's lead from modelV2.leadsV3[0] for radarless cars. modelV2's lateral is +right, so we negate it to match
-  the dash's +left. v is made relative (v - vEgo) for the smoother's feed-forward. Lead is inactive when the
-  lead is missing or below LEAD_PROB_ON.
-  """
-  if model is None or len(model.leadsV3) == 0:
-    return ModelLead(False, 0.0, 0.0, 0.0)
-  lead = model.leadsV3[0]
-  if len(lead.x) == 0:
-    return ModelLead(False, 0.0, 0.0, 0.0)
-  # data is populated below LEAD_PROB_ON too (status False): the HUD author's hysteresis keeps an
-  # already-rendered lead alive down to LEAD_PROB_OFF instead of blinking it at the 0.5 threshold
-  return ModelLead(bool(lead.prob >= LEAD_PROB_ON), float(lead.x[0]), -float(lead.y[0]),
-                   float(lead.v[0]) - v_ego, prob=float(lead.prob))
+  """OP's lead from modelV2.leadsV3[0] (see leads_from_model)."""
+  return leads_from_model(model, v_ego, n=1)[0]
 
 
 def create_hud_object(packer, bus, mux, track):
@@ -284,6 +273,38 @@ class HudObjectAuthor:
     self._lead_on = False   # hysteresis state for the rendered lead
     self._lead_hold: ModelLead | None = None   # last rendered lead, for the drop-hold bridge
     self._lead_seen_t = -1e9
+    # distinct leadsV3[1]/[2] rendered as non-lead cars in slots 1-2 (CAN FD, where tracks is None)
+    self._extra_ids = {slot: LeadObjectId() for slot in EXTRA_LEAD_SLOTS}
+    self._extra_smooth = {slot: LeadSmoother() for slot in EXTRA_LEAD_SLOTS}
+    self._extra_emit = dict.fromkeys(EXTRA_LEAD_SLOTS, 0)   # emitted OBJECT_ID per extra slot
+
+  def _update_extras(self, extra_leads, lead, in_use, now):
+    """Per-tick state update for the extra leads; returns {slot: track-dict-or-None}. Extras must
+    stay distinct from the primary lead and from each other, and their OBJECT_IDs must not collide
+    with the primary's or one another's."""
+    rendered = [(lead.dRel, lead.yRel)] if lead.status else []
+    out = {}
+    for slot, ex in zip(EXTRA_LEAD_SLOTS, extra_leads or (), strict=False):
+      distinct = ex.status and all(abs(ex.dRel - d) >= EXTRA_LEAD_MIN_SEP_D or
+                                   abs(ex.yRel - y) >= EXTRA_LEAD_MIN_SEP_Y
+                                   for d, y in rendered)
+      op_id = self._extra_ids[slot].update(distinct, ex.dRel, ex.vRel, now)
+      if not distinct:
+        self._extra_emit[slot] = 0
+        out[slot] = None
+        continue
+      emit = self._extra_emit[slot]
+      if emit == 0 or emit in in_use:
+        emit = op_id
+        while emit in in_use:
+          emit = emit % MAX_OBJECT_ID + 1
+        self._extra_emit[slot] = emit
+      in_use.add(emit)
+      d_rel, y_rel = self._extra_smooth[slot].update(ex.dRel, LAT_SCALE * ex.yRel, ex.vRel, emit, now)
+      rendered.append((ex.dRel, ex.yRel))
+      out[slot] = {"d_rel": d_rel, "y_rel": y_rel, "object_id": emit, "is_lead_car": 0,
+                   "car_type": CAR_TYPE_CAR, "rotation": lead_rotation(y_rel / LAT_SCALE)}
+    return out
 
   def _gate_lead(self, lead: ModelLead, now: float) -> ModelLead:
     """On/off hysteresis + short drop-hold for the rendered lead. leadsV3[0].prob hovers around the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Repairs the conflict reconciliation of [PR #629](https://github.com/mvl-boston/opendbc/pull/629) (commit 7e4cbb5) in `opendbc/car/honda/hud_objects.py`. PR #629 was written against `canfd-timer`, which lacks the extra-leads feature this branch gained in 264ab34bf; the resolution took the PR's side of the `HudObjectAuthor` conflict wholesale, breaking two things:

1. **Crash on CAN FD**: `_update_extras` and its `__init__` state (`_extra_ids`, `_extra_smooth`, `_extra_emit`) were deleted while `create()` kept calling it, so every authored HUD frame with `tracks is None` raised `AttributeError` in the carcontroller loop. This restores the method and state exactly as authored in 264ab34bf.

2. **Lead marker never rendered**: the carcontroller feeds slot 0 from `leads_from_model(...)[0]`, which neither carried `prob` nor kept data below `LEAD_PROB_ON`, so the PR's `_gate_lead` hysteresis never latched (`prob` defaulted to 0.0) and the lead marker never rendered on any OP-long authoring path — radarless included. `leads_from_model` now applies the PR's per-entry semantics (status = `prob >= LEAD_PROB_ON`, data + prob kept whenever populated, so the 0.35–0.5 hysteresis band renders from real coordinates), and `lead_from_model` is folded back into it as `leads_from_model(model, v_ego, n=1)[0]`, un-deadening it.

The extras path gates rendering on `ex.status`, so entries now carrying sub-threshold data don't change its behavior.

Offline harness results: CAN FD `create()` packs frames without crashing; a 0.9-prob lead renders, keeps rendering through the 0.35–0.5 band on real data, dead-reckons the 0.6 s drop-hold, then blanks; a distinct `leadsV3[1]` renders in slot 1 while a same-car `leadsV3[2]` is deduped to inactive. `ruff` clean, `opendbc/car/honda/tests/test_honda.py` passes.

Validation
* Dongle ID: n/a (offline harness only — needs on-car confirmation per #629's notes)
* Route: n/a
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d6b5b7f-8a28-4794-84c9-f11ab658020a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d6b5b7f-8a28-4794-84c9-f11ab658020a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

