### PR TITLE
Honda: fix ICBM call to spam_buttons_command (missing ambient_light args)

### DIFF
--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -500,7 +500,7 @@ class CarController(CarControllerBase, MadsCarController, GasInterceptorCarContr
             self.gas = pcm_accel / self.params.NIDEC_GAS_MAX
 
     # Intelligent Cruise Button Management
-    can_sends.extend(IntelligentCruiseButtonManagementInterface.update(self, CC_SP, self.packer, self.frame,
+    can_sends.extend(IntelligentCruiseButtonManagementInterface.update(self, CC_SP, CS, self.packer, self.frame,
                                                                        self.last_button_frame, self.CAN))
 
     # Render OP's lane and lead car on the dash. On CAN FD these are radar look-alikes that only exist

--- a/opendbc/sunnypilot/car/honda/icbm.py
+++ b/opendbc/sunnypilot/car/honda/icbm.py
@@ -24,7 +24,7 @@ class IntelligentCruiseButtonManagementInterface(IntelligentCruiseButtonManageme
   def __init__(self, CP, CP_SP):
     super().__init__(CP, CP_SP)
 
-  def update(self, CC_SP, packer, frame, last_button_frame, CAN) -> list[CanData]:
+  def update(self, CC_SP, CS, packer, frame, last_button_frame, CAN) -> list[CanData]:
     can_sends = []
     self.CC_SP = CC_SP
     self.ICBM = CC_SP.intelligentCruiseButtonManagement
@@ -35,7 +35,7 @@ class IntelligentCruiseButtonManagementInterface(IntelligentCruiseButtonManageme
       send_button = BUTTONS[self.ICBM.sendButton]
 
       if (self.frame - self.last_button_frame) * DT_CTRL > 0.05:
-        can_sends.append(hondacan.spam_buttons_command(packer, CAN, send_button, self.CP.carFingerprint))
+        can_sends.append(hondacan.spam_buttons_command(packer, CAN, send_button, 0, CS.scm_ambient_light, self.CP.carFingerprint))
         self.last_button_frame = self.frame
 
     return can_sends


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes the `ty` type-check failure in [PR #636's CI run](https://github.com/mvl-boston/opendbc/actions/runs/31279505117/job/93158435297?pr=636):

```
error[missing-argument]: No arguments provided for required parameters `ambient_light`, `car_fingerprint` of function `spam_buttons_command`
  --> opendbc/sunnypilot/car/honda/icbm.py:38:26
```

`spam_buttons_command` in `opendbc/car/honda/hondacan.py` gained `cruise_setting` and `ambient_light` parameters (the camera consumes the `AMBIENT_LIGHT_MAYBE` byte of `SCM_BUTTONS` for adaptive high beam, so the SCM's live value must be echoed), but the sunnypilot Intelligent Cruise Button Management interface was still calling it with the old signature — passing `carFingerprint` in the `cruise_setting` slot and omitting the last two arguments.

## Changes

- `opendbc/sunnypilot/car/honda/icbm.py`: `update()` now takes `CS` and passes `cruise_setting=0` (matching the existing cancel/resume spam calls in the car controller) and the live `CS.scm_ambient_light` to `spam_buttons_command`.
- `opendbc/car/honda/carcontroller.py`: forwards `CS` to `IntelligentCruiseButtonManagementInterface.update()`.

## Verification

`ty check` passes across the whole repo (previously reported 1 diagnostic).

Note: the CI run also shows `vEgoStopping` capnp schema errors in the "test models" jobs; those come from a schema mismatch with the openpilot side and are unrelated to this fix.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc5080f4-b261-4693-81ca-a37a91437b74?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc5080f4-b261-4693-81ca-a37a91437b74&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

