### PR TITLE
Honda CAN FD: trigger stock-LKAS auto-disable from radar LKAS_HUD_2 lane display

### DIFF
--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -151,6 +151,7 @@ class CarController(CarControllerBase):
 
     self.lkas_button_send_remaining = 0
     self.last_lkas_button_frame = 0
+    self.lkas_hud2_button_bursts = 0
     self.radar_disable_counter = 0
 
     self.gasfactor = 1.0 if (Params().get("HondaGasFactorParams") is None) else Params().get("HondaGasFactorParams")
@@ -533,8 +534,19 @@ class CarController(CarControllerBase):
     # accepted by the camera).
     if self.CP.carFingerprint in (HONDA_BOSCH_RADARLESS | HONDA_BOSCH_CANFD) and CC.enabled and self.frame % 4 == 0 and \
         not pcm_cancel_cmd and not CC.cruiseControl.resume:
-      if self.lkas_button_send_remaining == 0 and CS.lkas_hud["LKAS_READY"] and self.frame >= self.last_lkas_button_frame + 500:
-        self.lkas_button_send_remaining = 3
+      if self.lkas_button_send_remaining == 0 and self.frame >= self.last_lkas_button_frame + 500:
+        if CS.lkas_hud["LKAS_READY"]:
+          self.lkas_button_send_remaining = 3
+        elif CS.lkas_hud2_lane_display and self.lkas_hud2_button_bursts < 3:
+          # Newer CAN FD radar firmware (CR-V 6G A220) keeps the lane display armed across ignition
+          # cycles and shows it only radar-side (LKAS_HUD_2 on the pt bus) -- the camera never asserts
+          # LKAS_READY, yet the armed display runs the touch-steering-wheel timer that ends in a
+          # full FCM/LKAS/RDM fault ~3-4 min in (CR-V 6G routes cf8efca14d378c49/00000000/1/2).
+          # The button is a toggle and this firmware's response to it is unverified, so cap the
+          # bursts triggered by this path: if the display doesn't disarm, endless on/off cycling
+          # would be worse than the nag. LKAS_READY-triggered bursts above stay uncapped.
+          self.lkas_hud2_button_bursts += 1
+          self.lkas_button_send_remaining = 3
 
       if self.lkas_button_send_remaining > 0:
         self.last_lkas_button_frame = self.frame

--- a/opendbc/car/honda/carstate.py
+++ b/opendbc/car/honda/carstate.py
@@ -56,6 +56,7 @@ class CarState(CarStateBase):
 
     self.initial_accFault_cleared = False
     self.initial_accFault_cleared_timer = int(10 / DT_CTRL) # 10 seconds after startup for initial faults to clear
+    self.lkas_hud2_lane_display = False
     self.radar_ref_counter = 0
     self.radar_5hz_tick_counter = 0
     self.radar_5hz_tick = False
@@ -284,6 +285,15 @@ class CarState(CarStateBase):
     if self.CP.carFingerprint in (HONDA_BOSCH_RADARLESS | HONDA_BOSCH_CANFD):
       self.lkas_hud = cp_cam.vl["LKAS_HUD"]
     if self.CP.carFingerprint in HONDA_BOSCH_CANFD:
+      # Newer CAN FD radar firmware (e.g. CR-V 6G with 8S302-3A0-A220) authors LKAS_HUD_2 (0xF31AA54)
+      # on the powertrain bus, streaming nonzero LANE_WIDTH/LANE_LENGTH whenever the cluster's moving
+      # lane-line display is armed -- including when the state persisted across an ignition cycle and
+      # the camera never asserts LKAS_READY. That armed state runs the stock touch-steering-wheel
+      # timer, which openpilot's blocked camera actuation can never satisfy, so ~3-4 min later the
+      # radar latches an FCM/LKAS/RDM fault and ACC locks out for the drive. Both signals read 0 on
+      # radars that don't emit the message (e.g. MDX 4G), and the radar blanks them once faulted.
+      self.lkas_hud2_lane_display = cp.vl["LKAS_HUD_2"]["LANE_WIDTH"] != 0 or cp.vl["LKAS_HUD_2"]["LANE_LENGTH"] != 0
+
       # The radar emits low-rate "tick reference" messages that keep running even while the radar's
       # data messages are disabled, so we phase our look-alikes to the stock cadence off of them.
       #
@@ -377,6 +387,10 @@ class CarState(CarStateBase):
       # Both messages intentionally go silent (the radar is disabled, the camera ends up behind the
       # open relay), so subscribe with NaN frequency to skip the alive/timeout checks.
       pt_messages += [("ACC_CONTROL", float('nan')), ("STEERING_CONTROL", float('nan'))]
+      # Stock-radar-authored lane-display state (see update); not all CAN FD radars emit it (the
+      # MDX 4G doesn't), so subscribe with NaN frequency to skip the alive/timeout checks. Verified
+      # against CR-V 6G A220 radar logs: the stock stream passes the Honda checksum/counter checks.
+      pt_messages += [("LKAS_HUD_2", float('nan'))]
     if CP.carFingerprint in HONDA_BOSCH_RADARLESS:
       # HUD_OBJECTS is polled by the HudObjectTracker, but not every radarless camera emits it,
       # so subscribe with NaN frequency to skip the alive/timeout checks.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The CAN FD stock-LKAS auto-disable (from `d79efd7dc`) triggers on the camera's `LKAS_HUD.LKAS_READY`. On newer CAN FD radar firmware (CR-V 6G, radar `8S302-3A0-A220` / camera `8S102-3A0-A240`), the cluster's moving lane-line display arms **persistently across ignition cycles** and is visible only radar-side — `LKAS_HUD_2` (0xF31AA54) streaming nonzero `LANE_WIDTH`/`LANE_LENGTH` on the powertrain bus — while the camera never asserts `LKAS_READY`. The armed display runs the stock touch-steering-wheel timer, and since openpilot blocks the camera's actuation, it expires into a **permanent FCM/LKAS/RDM fault + ACC lockout** ~3–4 min into every drive, engaged or not.

Evidence (dongle `cf8efca14d378c49`, stock release-mici 0.11.1):

| Route | Arming | Fault latch |
|---|---|---|
| 00000000 | `LKAS_HUD_2` streaming from t=0 (persisted), `LKAS_READY`=0 all drive, never engaged | 166 s |
| 00000001 | driver LKAS button at 31.9 s (`LKAS_READY`→1), never engaged | 242 s (210 s after arming) |
| 00000002 | `LKAS_HUD_2` streaming from t=0, `LKAS_READY`=0 all drive, engaged 6x | 229 s |

Comparators: validation CR-V (`2dc4489d7e1410ca/00000001`, old A060/A090 firmware, no `LKAS_HUD_2` emitted, LKAS never armed) drove 13 min engaged with zero faults; MDX (`ad9840558640c31d/0000004f`) emits no 0xF31AA54 at all and never developed the timer fault.

## Change

- Subscribe `LKAS_HUD_2` on the CAN FD pt parser with **NaN frequency** (same tolerance pattern as radarless `HUD_OBJECTS`): cars whose radar doesn't emit it (MDX 4G) read constant zeros and skip all alive/timeout checks — `can_valid` is unaffected.
- `CS.lkas_hud2_lane_display` = `LANE_WIDTH != 0 or LANE_LENGTH != 0`.
- The existing auto-disable button burst also fires on this trigger, **capped at 3 bursts per drive**: the button is a toggle and this firmware's response is unverified on-car, so if the display doesn't disarm we stop rather than cycle LKAS on/off forever. The `LKAS_READY` path is unchanged and uncapped, and takes priority.

Engagement gating is intentionally left as-is (deferred per discussion; the safety code only admits the 0x296 takeover stream while `controls_allowed`).

## Verification (offline)

- All **1505** stock `LKAS_HUD_2` frames from `cf8efca14d378c49/00000002` parse through `CANParser`: Honda checksum passes, `counter_fail` stays 0, `can_valid` true. Decode: `LANE_WIDTH` 29–35 / `LANE_LENGTH` 6–15 while armed from t=0, both exactly 0 once the radar faults at 228.9 s (`SET_ME_X01` stays 1, so it's not used as the trigger).
- Simulated MDX drive (message never arrives): parser stays valid, signals read 0, no behavior change.
- CarController harness (CR-V 6G CP, engaged): hud2-only trigger → exactly 3 bursts of 3 press-frames with 5 s spacing, then stops; no trigger → zero presses; `LKAS_READY` trigger → uncapped, identical to before; both triggers → `LKAS_READY` path takes priority without consuming the cap.
- 356 honda safety tests pass (no safety code touched); ruff clean.

## On-car test needed

The car currently boots pre-armed, so a single 5+ min drive with engagement covers it: expect up to 3 LKAS toggle bursts shortly after first engagement, the radar lane display (`LKAS_HUD_2` width/length) dropping to 0, and no FCM/LKAS/RDM fault at the ~3–4 min mark. If the display does not disarm after 3 bursts, the toggle isn't accepted by this firmware and the fallback is mirroring the press on bus 0 (the radar also listens to `SCM_BUTTONS` there).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91e387f1-2fa7-4700-a8fb-d122bd748737?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91e387f1-2fa7-4700-a8fb-d122bd748737&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

