### PR TITLE
Self-bounding speedfactor learner with learned servo ceiling (sat_accel)

### DIFF
--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -181,6 +181,12 @@ class CarController(CarControllerBase):
     self.windfactor_before_gasmax = self.windfactor_before_brake = self.windfactor
     self.speedfactor = 4.0 if (Params().get("HondaSpeedFactorParams") is None) else Params().get("HondaSpeedFactorParams")
     self.speedalpha = 0.0 if (Params().get("HondaSpeedAlphaParams") is None) else Params().get("HondaSpeedAlphaParams")
+    # learned ceiling of the pcm_speed servo channel (m/s2): the most accel the plant delivers
+    # no matter how large the speed lead gets. The servo's responsive band ends at
+    # dv_sat = speedfactor * sat_accel, where the responsive line (accel = dv/speedfactor)
+    # meets this ceiling.
+    self.sat_accel = 0.9 if (Params().get("HondaSatAccelParams") is None) else Params().get("HondaSatAccelParams")
+    self.deficit_frames = 0
     self.new_accel = 0.0
 
     self.latFactors = {
@@ -346,7 +352,30 @@ class CarController(CarControllerBase):
       if (self.new_accel == self.params.NIDEC_GAS_MAX) and (not CS.out.gasPressed) and \
            (self.apply_brake_last == 0): # adjust speedfactor
         speedfactor_error = (self.accel - CS.out.aEgo)
-        self.speedfactor *= (1 + 0.0001 * speedfactor_error * self.accel)
+        dv_sent = self.speedfactor * self.accel + self.speedalpha
+        dv_sat = max(0.1, self.speedfactor * self.sat_accel)
+
+        # ceiling learner (sat_accel): owns the saturated regime, learns by direct measurement.
+        # Asymmetric on purpose: a ceiling is a max-type quantity, so learn UP quickly whenever the
+        # plant demonstrably beats the estimate, and drift DOWN only under persistent deficit
+        # (undershooting for well past the ~1s plant lag with everything maxed means whatever aEgo
+        # we observe IS the ceiling). Raw aEgo, no hill term: the ceiling is a servo logic cap that
+        # is grade-compensated downstream (hill belongs on the gas channel only).
+        self.deficit_frames = self.deficit_frames + 1 if (speedfactor_error > 0.1 and CS.out.vEgo > 1.0) else 0
+        if (CS.out.aEgo > self.sat_accel) and (dv_sent > dv_sat):
+          self.sat_accel = float(np.clip(self.sat_accel + 0.002 * (CS.out.aEgo - self.sat_accel), 0.1, self.params.NIDEC_ACCEL_MAX))
+        elif self.deficit_frames > 150:
+          self.sat_accel = float(np.clip(self.sat_accel + 0.0002 * (CS.out.aEgo - self.sat_accel), 0.1, self.params.NIDEC_ACCEL_MAX))
+
+        # speedfactor: only move it where moving it changes the output. Error feedback is only
+        # sign-correct below the knee; beyond it the surplus speed lead provably does nothing
+        # (measured: ~0.03 (m/s2)/(m/s) response above the knee vs ~0.2 below), so bleed toward
+        # the knee instead of growing on an error that can never respond. The min() is a per-tick
+        # rate limit (0.5%/tick max), same family as the gas/brake slew limits.
+        if dv_sent > dv_sat:
+          self.speedfactor *= (1 - min(0.0005 * (dv_sent - dv_sat), 0.005))
+        else:
+          self.speedfactor *= (1 + 0.0001 * speedfactor_error * self.accel)
         self.speedalpha += (0.001 * speedfactor_error)
         if max_speedcontrol: # only allow learning reductions
           self.speedfactor = min(prior_speedfactor, self.speedfactor)
@@ -499,6 +528,7 @@ class CarController(CarControllerBase):
         "HondaWindFactorParams": self.windfactor,
         "HondaSpeedAlphaParams": self.speedalpha,
         "HondaSpeedFactorParams": self.speedfactor,
+        "HondaSatAccelParams": self.sat_accel,
       })
 
     if self.frame % 12000 == 30:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The Nidec speedfactor learner grows without bound (4 → 306 across July drives; ~85 at route `000001db`, producing 300+ km/h `PCM_SPEED` setpoints on the wire). Tick-level forensics on route `000001d7` show why: 77% of growth ticks had a sent speed lead (`dv`) beyond the servo's responsive band, where the plant fit shows ~0.03 (m/s²)/(m/s) marginal response vs ~0.2 below — so the tracking error the learner integrates can never respond to the parameter it's adjusting, and it grows forever. The only guard (`max_speedcontrol`) binds at the 100 m/s wire clip.

## Approach

Only move `speedfactor` where moving it observably changes the output, and prefer the smallest value that produces the same output. The servo knee is not learned directly (and not hard-coded, so this ports to other cars): it's derived per tick as `dv_sat = max(0.1, speedfactor * sat_accel)`, where `sat_accel` is a new learned parameter — the acceleration ceiling of the speed channel:

- **`sat_accel`** (persisted as `HondaSatAccelParams`, default 0.9, clipped `[0.1, NIDEC_ACCEL_MAX]`): learned by direct measurement, not error integration. Asymmetric on purpose (ceiling = max-type quantity): learns up fast (0.002) whenever observed `aEgo` beats the estimate while `dv` is beyond the knee; drifts down slowly (0.0002) only after >1.5 s of persistent deficit (undershooting well past the plant lag with gas pinned means observed `aEgo` *is* the ceiling). Raw `aEgo`, no hill term — the ceiling is a servo logic cap, grade-compensated downstream (hill stays on the gas channel per prior grade analysis).
- **`speedfactor`**: error feedback only below the knee (where error sign flips around the true value); above the knee it bleeds toward it at `min(0.0005 * (dv_sent - dv_sat), 0.005)` per tick — the `min` is a 0.5%/tick rate limit (robustness bound, same family as the gas/brake slew limits, not a plant constant).

Regime ownership stays disjoint (no two-integrator fights): `speedfactor` owns the responsive band via error feedback, `sat_accel` owns the saturated regime via direct measurement, `dv_sat` is derived, and the gas-channel learners keep their existing `0 < new_accel < 198` gate vs this block's `== 198`.

## Validation (offline replay, route 000001d7)

Replayed tick-by-tick against recorded data and against synthetic plants (first-order lag 0.8 s):

| scenario | speedfactor trajectory |
|---|---|
| recorded data, poisoned start 85 | → below 12 at ~7 min (city profile), settles ~5.6 |
| synthetic gain 0.30 / ceiling 1.5 (truth sf 3.33), start 4.0 | → 2.9 |
| same plant, start at truth (3.3 / 1.5) | stays put (stable fixed point) |
| synthetic gain 0.45 / ceiling 0.9 (truth sf 2.2), start 81 | → 4.6 in one route |
| current code, same recorded data, start 81 | drifts up to ~83 |

Convergence from a poisoned state is event-driven: it needs ~570 accumulated ticks of demand above the learned ceiling with gas pinned (launches / hard pulls), i.e. minutes of city driving. On gentle profiles a pre-existing poisoned value persists visibly (by design — no forced reset) but does not worsen; an unpoisoned car cannot become poisoned since growth only happens below the knee.

Existing `max_speedcontrol` reduction-only backstop is retained. `speedalpha` update unchanged.

Requires `HondaSatAccelParams` in the openpilot fork's params (already added).

## Testing

- `python3 -m py_compile` passes; learner dynamics validated via the offline replays above.
- Not yet driven on-car.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b714fa34-53ab-4993-a1b1-0ec3b73fd1a0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b714fa34-53ab-4993-a1b1-0ec3b73fd1a0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

