### PR TITLE
Nidec: stock-signature standstill launch to beat camera ACC_PROBLEM watchdog

### DIFF
--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -17,6 +17,16 @@ from opendbc.car.common.pid import PIDController
 VisualAlert = structs.CarControl.HUDControl.VisualAlert
 LongCtrlState = structs.CarControl.Actuators.LongControlState
 
+# Stock Nidec camera launch signature (measured on ACURA_MDX_3G route 153): at a standstill
+# resume the camera jumps straight to PCM_SPEED=9.99 kph + PCM_GAS~104 and the PCM starts
+# applying pedal within ~0.2s. Anything weaker (gas ramped from 0, tiny speed lead) adds
+# ~0.4s of PCM response lag — enough to lose the launch race against the camera's shadow-ACC
+# watchdog, which latches ACC_PROBLEM ~0.8s after ITS launch if the car has not moved and the
+# engine is running (engine-off/idle-stop launches are tolerated much longer; see route 1db
+# fault vs 1d7 twins).
+NIDEC_LAUNCH_PCM_SPEED = 9.99 * CV.KPH_TO_MS  # m/s
+NIDEC_LAUNCH_PCM_GAS = 104
+
 
 def compute_gb_honda_bosch(accel, speed):
   # TODO returns 0s, is unused
@@ -188,6 +198,7 @@ class CarController(CarControllerBase):
     self.sat_accel = 0.9 if (Params().get("HondaSatAccelParams") is None) else Params().get("HondaSatAccelParams")
     self.deficit_frames = 0
     self.new_accel = 0.0
+    self.launching = False
 
     self.latFactors = {
       "05": 1.0 if (Params().get("HondaLatAccelFactor05Params") is None) else Params().get("HondaLatAccelFactor05Params"),
@@ -223,6 +234,12 @@ class CarController(CarControllerBase):
       if (actuators.longControlState in (LongCtrlState.pid, LongCtrlState.stopping)) and \
          (CS.out.vEgo > 1e-5 or actuators.accel > 1e-5) \
          and (not CS.out.stockAeb) and (not CS.out.gasPressed):
+        if CS.out.vEgo < 1e-2 and actuators.accel > 1e-5:
+          # standstill resume: integral wound during the braking approach is stale — it can
+          # only delay the launch and hold the brake into it (1db fault: i=-0.94 cost 0.35s
+          # plus a brake spike overlapping the camera launch). Drop the negative part now
+          # instead of unwinding it through k_i.
+          self.nidec_pid.i = max(self.nidec_pid.i, 0.0)
         self.nidec_pid_factor = self.nidec_pid.update(error = actuators.accel - CS.out.aEgo, speed = CS.out.vEgo)
         self.accel = actuators.accel + self.nidec_pid_factor
         adjust_accel = self.accel + hill_brake
@@ -263,6 +280,14 @@ class CarController(CarControllerBase):
       self.accel = 0.0
       adjust_accel = self.accel
       brake = 0.0
+
+    # launch latch: set at an engaged standstill the moment the planner wants to go, cleared
+    # once rolling (or on any reason not to go). While latched the Nidec send path floors the
+    # commands to the stock launch signature so the PCM responds at stock speed.
+    if CC.longActive and (not CS.out.gasPressed) and CS.out.vEgo < 1e-2 and actuators.accel > 1e-5:
+      self.launching = True
+    elif (not CC.longActive) or CS.out.gasPressed or (actuators.accel <= 1e-5) or (CS.out.vEgo > 1.5):
+      self.launching = False
 
     # *** rate limit steer ***
     limited_torque = rate_limit(actuators.torque, self.last_torque, -self.params.STEER_DELTA_DOWN * DT_CTRL,
@@ -485,13 +510,21 @@ class CarController(CarControllerBase):
           self.apply_brake_last = apply_brake
           self.brake = apply_brake / self.params.NIDEC_BRAKE_MAX
 
+      if self.CP.carFingerprint not in HONDA_BOSCH and self.launching and \
+          (self.apply_brake_last == 0) and (not CS.out.gasPressed):
+        # stock-signature launch: our brake is off and the planner wants to go, so command at
+        # least what the stock camera commands at a launch. Skipping the ramp-from-zero here is
+        # what wins the race against the camera's engine-on no-motion watchdog (~0.8s).
+        pcm_speed = max(pcm_speed, NIDEC_LAUNCH_PCM_SPEED)
+        self.new_accel = max(self.new_accel, NIDEC_LAUNCH_PCM_GAS)
+
     # Send dashboard UI commands.
     if self.frame % 10 == 0:
 
       if self.CP.openpilotLongitudinalControl:
         # On Nidec, this also controls longitudinal positive acceleration
         can_sends.append(hondacan.create_acc_hud(self.packer, self.CAN.pt, self.CP, CC.enabled, pcm_speed, self.new_accel,
-                                                 hud_control, hud_v_cruise, CS.is_metric, CS.acc_hud))
+                                                 hud_control, hud_v_cruise, CS.is_metric, CS.acc_hud, self.launching))
 
       steering_available = CS.out.cruiseState.available and CS.out.vEgo > max(self.params.STEER_GLOBAL_MIN_SPEED, self.CP.minSteerSpeed)
       reduced_steering = CS.out.steeringPressed

--- a/opendbc/car/honda/hondacan.py
+++ b/opendbc/car/honda/hondacan.py
@@ -144,7 +144,7 @@ def create_bosch_supplemental_1(packer, CAN):
   return packer.make_can_msg("BOSCH_SUPPLEMENTAL_1", CAN.lkas, values)
 
 
-def create_acc_hud(packer, bus, CP, enabled, pcm_speed, pcm_accel, hud_control, hud_v_cruise, is_metric, acc_hud):
+def create_acc_hud(packer, bus, CP, enabled, pcm_speed, pcm_accel, hud_control, hud_v_cruise, is_metric, acc_hud, launching=False):
   acc_hud_values = {
     'CRUISE_SPEED': hud_v_cruise,
     'ENABLE_MINI_CAR': 1 if enabled else 0,
@@ -164,7 +164,8 @@ def create_acc_hud(packer, bus, CP, enabled, pcm_speed, pcm_accel, hud_control, 
     acc_hud_values['ACC_ON'] = int(enabled)
     acc_hud_values['PCM_SPEED'] = pcm_speed * CV.MS_TO_KPH
     acc_hud_values['PCM_GAS'] = pcm_accel
-    acc_hud_values['SET_ME_X01'] = 1 if (pcm_accel == 0 or pcm_accel == 198) else 0
+    # "power/accelerate-to-set-speed" flag; stock sets it during resume and power ramps
+    acc_hud_values['SET_ME_X01'] = 1 if (launching or pcm_accel == 0 or pcm_accel == 198) else 0
     acc_hud_values['FCM_OFF'] = acc_hud['FCM_OFF']
     acc_hud_values['FCM_OFF_2'] = acc_hud['FCM_OFF_2']
     acc_hud_values['FCM_PROBLEM'] = acc_hud['FCM_PROBLEM']


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Research summary (route `000001db--b530ab8015` fault, `000001d7--33a9e957de` twins)

Full rlog analysis of all 29 `1d7` segments plus the `1db` fault window and the stock route `00000153` refined the picture:

**What the fault is.** The factory camera runs a shadow ACC and auto-launches when a lead departs from an engaged standstill (`PCM_SPEED=9.99` kph + `PCM_GAS~104` on bus 2). About **0.8s after its own launch**, if the car still has not moved **and the engine is running**, it latches `ACC_PROBLEM` (fault at 206.33 = camera launch 205.53 + 0.80s). Engine-off (idle-stop) launches get a much longer leash: in the `1d7` twins the camera tolerated 2.1s+ of no motion and then *abandoned* the launch gracefully (its gas fell to 14) with no fault.

**Hypotheses killed by the new data:**
- *"comma brakes while factory accelerates"*: the `1d7` seg-6 twin had a **worse** brake overlap (our brake 58 at camera launch, released +0.31s vs 38/+0.17s in the fault case) and no fault.
- *"engine revving"*: the rpm rise in the fault window was 936→1008 — ordinary idle wobble. `1d7` @1237s had an engine-ON resume (rpm 970) with no fault — but there the car was already moving when the camera's launch tracking kicked in, so the camera never saw an engine-on no-motion launch.
- The pending test case (`1d7` @947.9s, 2.6s hold) turned out to be engine-off with no camera launch at all — not a discriminator.

**The controllable factor is our resume latency.** In the fault window the PCM applied **zero** CAR_GAS the entire launch (engine never got a pedal command; the "rev" was idle). Measured PCM response at standstill: **0.18s** to a stock launch signature (3 launches in route 153) vs **0.56–0.6s** to our ramp-from-zero gas with a wild `pcm_speed` (two `1d7` events). Our first positive wire command came 0.27s after the camera launch (0.4s lost to the wound-negative `nidec_pid` integral + the brake spike it caused), and gas then ramped +20/frame — 100+ only at camera+0.67s. The PCM would have responded right around 206.4; the camera faulted at 206.33. We lost the race by ~0.1s.

## The fix

1. **Clear negative `nidec_pid.i` at a standstill resume** (`vEgo<0.01` and plan accel > 0). The integral wound during the braking approach is stale brake-regime state: it delayed the wire command 0.35s and held a ~110-unit brake spike into the camera's launch.
2. **Stock-signature launch latch**: from an engaged standstill with positive plan accel until rolling (>1.5 m/s), once our brake is fully released, floor the Nidec wire commands to the measured stock launch: `PCM_SPEED ≥ 9.99 kph`, `PCM_GAS ≥ 104`. Skipping the ramp-from-zero is what buys the ~0.4s of PCM response time.
3. **`SET_ME_X01=1` while launching** (stock's power/resume-ramp flag).

Gas+brake overlap protection is preserved: floors are gated on `apply_brake_last == 0` and not `gasPressed`, and the existing brake-active zeroing still runs first.

## Validation

- Tick-replay harness (hand port) validated against the recorded `1db` wire data (gas frames match within one frame, PID trace within 0.1, brake profile shape matches).
- The **real patched controller** (stubbed `Params`, `CarControl` from recorded route inputs, hybrid `CP.flags`) replayed over the fault window:
  - brake fully released at **camera+0.01s** (was +0.20s)
  - first wire frame at **camera+0.07s** already carries the full launch signature (was: weak gas 20 at +0.27s, ≥100 only at +0.67s)
  - with converged learner params the wire is indistinguishable from stock: `spd=9.99 gas=104→122→165 x01=1`
  - projected motion at ~206.0–206.1 vs fault deadline 206.33 (~0.25s margin), using the measured 0.18s stock-signature PCM lag + the 0.2–0.3s engine-on pedal-to-motion time demonstrated by the driver's own gas press in the same log.
- `pytest opendbc/safety/tests/test_honda.py`: **296 passed** (matches baseline); honda car tests pass.

## Residual risk / notes

- The 0.18s PCM lag was measured on engine-off (EV) stock launches; no engine-on stock standstill launch exists in the available routes. Engine-on response to a pedal was faster (~0.2s driver press → motion), so the margin estimate is conservative in one direction and unverified in the other. If a fault recurs, the next lever is triggering the launch off the camera's own bus-2 launch frames (available in `CS`), which would gain another ~0.1s of head start when the camera leads the planner.
- On the currently-poisoned device params (speedfactor≈85, gasfactor≈49) the launch still sends absurd `pcm_speed` after the first floored frame; the shipped `sat_accel` learner bleeds that over the next drives. The Nidec `gasfactor` learner still has no clamp (background failure mode #1/#7) — out of scope here, still worth shipping separately.

### Background-file lines to append

```
- 1DB FAULT ROOT CAUSE REFINED (2026-08, full 1d7 rlogs): camera shadow-ACC watchdog: latches ACC_PROBLEM
  ~0.8s after ITS standstill auto-launch if no motion AND engine running; engine-off launches tolerated
  >2.1s then abandoned (gas->14, no fault). Brake-overlap hypothesis dead (twin overlap worse, no fault).
  "Revving" was idle wobble; PCM applied ZERO CAR_GAS all fault window. PCM standstill pedal response:
  0.18s to stock launch signature (9.99kph+gas104, 3x in route 153) vs 0.56-0.6s to ramp-from-zero gas
  (2x in 1d7). We lost by ~0.1s: plan flip 205.40, first wire gas 205.81 (pid.i=-0.94 unwind 0.35s +
  brake spike 110 overlap), 100+ gas only cam+0.67s, fault 206.33.
- FIX (branch cursor/mdx-standstill-launch-fault-2500): standstill-resume pid.i negative clear + launch
  latch (standstill origin, until v>1.5) flooring wire to stock signature (pcm_speed>=9.99kph, gas>=104,
  X01=1) once our brake released. Real-controller replay on 1db inputs: full signature on wire cam+0.07s,
  brake released cam+0.01s, projected motion ~0.25s before deadline. Safety tests 296 passed.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1c34a7a-1712-43e8-b648-c428cff02500?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1c34a7a-1712-43e8-b648-c428cff02500&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

