### PR TITLE
Honda CAN FD: key dash LKAS indication on latActive for MADS

### DIFF
--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -475,9 +475,10 @@ class CarController(CarControllerBase, MadsCarController, GasInterceptorCarContr
         # steer_maxed used to be in here (via SOLID_LANES) and its 10Hz flicker during city-speed
         # steering re-triggered the pulse continuously, keeping LKAS_STATE_CHANGE high whenever a
         # real lane path was being sent - which suppressed the dash lane lines entirely.
-        # (latActive isn't in the key: DASHED_LANES is overridden to 1 on CAN FD, so it doesn't
-        # affect the payload.)
-        hud_key = (bool(hud_control.lanesVisible), bool(alert_steer_required), bool(CS.out.steerFaultPermanent))
+        # latActive drives SOLID_LANES (MADS keeps lateral engaged when ACC disengages, and the dash
+        # LKAS indication must follow it); DASHED_LANES is overridden to 1 on CAN FD, so lanesVisible
+        # no longer affects the payload.
+        hud_key = (bool(CC.latActive), bool(alert_steer_required), bool(CS.out.steerFaultPermanent))
         if hud_key != self.lkas_hud_key:
           self.lkas_hud_key = hud_key
           self.lkas_state_change_frames = 30  # 3s at the 10Hz LKAS_HUD rate, matching stock pulse length

--- a/opendbc/car/honda/hondacan.py
+++ b/opendbc/car/honda/hondacan.py
@@ -208,11 +208,14 @@ def create_lkas_hud(packer, bus, CP, hud_control, lat_active, steering_available
       lkas_hud_values['LKAS_PROBLEM'] = CS.out.steerFaultPermanent # CS.lkas_hud['LKAS_PROBLEM']
       lkas_hud_values['DASHED_LANES'] = 1  # show gray lanes when disengaged
 
-    if CP.carFingerprint in HONDA_BOSCH_CANFD:
-      # Don't let steer saturation flicker SOLID_LANES: every payload change must coincide with an
-      # LKAS_STATE_CHANGE pulse (see carcontroller), and a 10Hz flicker would keep the pulse
-      # re-triggering, which suppresses the dash lane lines.
-      lkas_hud_values['SOLID_LANES'] = hud_control.lanesVisible
+    # CAN FD keeps the top-level SOLID_LANES = lat_active: under sunnypilot MADS the lateral control
+    # stays engaged after a brake press disengages ACC, and the dash LKAS indication has to follow
+    # the lateral state or the driver can't tell MADS is still steering (using
+    # hud_control.lanesVisible == CC.enabled here made the dash show LKAS off while MADS steered,
+    # and drivers pressing the LKAS button to "re-engage" silently toggled MADS off).
+    # Don't add anything that flickers (e.g. steer_maxed) into SOLID_LANES: every payload change
+    # must coincide with an LKAS_STATE_CHANGE pulse (see carcontroller), and a 10Hz flicker keeps
+    # the pulse re-triggering, which suppresses the dash lane lines.
 
   if not (CP.flags & HondaFlags.BOSCH_EXT_HUD):
     lkas_hud_values['RDM_OFF'] = 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Tester report on `sp-honda-dev-202608` (Accord 11G, CAN FD): "lkas is gone when i press brake, i had to reengage both acc and lkas, stand alone lkas wont engage". This did not happen on `sp-honda-dev-202606`.

## Root cause

Introduced by the CAN-FD merge, not by sunnypilot upstream. Commit `e9c194084` ("Add alphalong fault prevention and extend lkas lines to Bosch C", part of the 202608 CAN-FD radar-replace merge) changed the CAN-FD `LKAS_HUD` to key `SOLID_LANES` on `hud_control.lanesVisible`, which controlsd sets from `CC.enabled` (ACC engagement). On the comma-based fork `enabled == latActive`, so this was harmless there.

Under sunnypilot MADS, lateral control stays engaged after a brake press disengages ACC — but the dash then showed LKAS off while MADS was still steering. The driver pressed the LKAS button to "re-engage", which silently toggled the still-active MADS **off** (with zero dash feedback, repeated presses just oscillated it), and the only visible recovery was pressing SET to re-engage ACC, which also brought the solid lanes back. So: LKAS *appeared* gone on brake, standalone LKAS *appeared* to not engage, and re-engaging ACC "fixed" it — exactly matching the report.

**Log evidence** (route `6504a94602f1de53|00000054--e187ba87c4`, rlogs):
- seg 17/27: after each brake press, `selfdriveState.enabled` goes false but MADS stays `enabled=True active=True`, and openpilot keeps commanding steer torque (600/600 `0xE4` frames non-zero during the seg-27 brake-hold window) — steering never actually stopped, only the dash indication did.
- seg 27 @1632.2s: genuine driver LKAS press (`0x296` src0, `CRUISE_SETTING=1`) turns the still-active MADS **off** (`lkasDisable`); driver then presses SET @1633.5s to recover.
- seg 28 @1694–1697s and @1735–1739s: driver presses LKAS 5 times in a row, MADS toggles off/on/off/on/off with no dash feedback.

## Fix

- `hondacan.create_lkas_hud`: CAN FD uses the top-level `SOLID_LANES = lat_active` (MADS-aware, same as 202606) instead of the `lanesVisible` override.
- `carcontroller`: the CAN-FD `LKAS_STATE_CHANGE` pulse key uses `CC.latActive` in place of `lanesVisible`, keeping the key exactly matched to the payload (the anti-flicker constraint that motivated the original change is preserved — `steer_maxed` stays out of the payload).

## Verification

- Offline CarController harness (ACCORD_11G, CAN FD): pre-fix, `LKAS_HUD` `SOLID_LANES=0` when `latActive=True, enabled=False` (the MADS-only post-brake state); post-fix `SOLID_LANES=1`. Fully-engaged payload is byte-identical to the factory lanes-on payload (`414400481800..`), and all-off still renders `SOLID_LANES=0`.
- `opendbc/safety/tests/test_honda.py`: 951 tests pass, 69 skipped.
- `opendbc/car/honda/tests/test_honda.py`: pass.
- `ruff check` on changed files: clean.
- Not yet verified on-car.

## Route

Route with the bug: `6504a94602f1de53|00000054--e187ba87c4` (segments 17, 27, 28)

## Related

This is the opendbc-side fix for the openpilot PR mvl-boston/openpilot#149, which pins its `opendbc_repo` submodule to this branch.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92aa1be4-85ad-42ca-b1f4-30e84cd6a105?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92aa1be4-85ad-42ca-b1f4-30e84cd6a105&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

