### PR TITLE
Honda CAN FD: restore MADS armed indication via DASHED_LANES

### DIFF
--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -476,9 +476,9 @@ class CarController(CarControllerBase, MadsCarController, GasInterceptorCarContr
         # steering re-triggered the pulse continuously, keeping LKAS_STATE_CHANGE high whenever a
         # real lane path was being sent - which suppressed the dash lane lines entirely.
         # latActive drives SOLID_LANES (under sunnypilot MADS the lateral control stays engaged
-        # when ACC disengages, and the dash LKAS indication follows it); DASHED_LANES is overridden
-        # to 1 on CAN FD, so hud_control.lanesVisible no longer affects the payload.
-        hud_key = (bool(CC.latActive), bool(alert_steer_required), bool(CS.out.steerFaultPermanent))
+        # when ACC disengages, and the dash LKAS indication follows it); dashed_lanes (MADS armed,
+        # from MadsCarController) drives DASHED_LANES so parked LKAS presses get cluster feedback.
+        hud_key = (bool(CC.latActive), bool(self.dashed_lanes), bool(alert_steer_required), bool(CS.out.steerFaultPermanent))
         if hud_key != self.lkas_hud_key:
           self.lkas_hud_key = hud_key
           self.lkas_state_change_frames = 30  # 3s at the 10Hz LKAS_HUD rate, matching stock pulse length

--- a/opendbc/car/honda/hondacan.py
+++ b/opendbc/car/honda/hondacan.py
@@ -197,7 +197,6 @@ def create_lkas_hud(packer, bus, CP, hud_control, lat_active, steering_available
 
   if CP.carFingerprint in (HONDA_BOSCH_RADARLESS | HONDA_BOSCH_CANFD):
     lkas_hud_values['LANE_LINES'] = 3
-    lkas_hud_values['DASHED_LANES'] = lat_active
 
     # car likely needs to see LKAS_PROBLEM fall within a specific time frame, so forward from camera
     # TODO: needed for Bosch CAN FD?
@@ -206,7 +205,15 @@ def create_lkas_hud(packer, bus, CP, hud_control, lat_active, steering_available
 
     if CP.carFingerprint in (HONDA_BOSCH_RADARLESS | HONDA_BOSCH_CANFD):
       lkas_hud_values['LKAS_PROBLEM'] = CS.out.steerFaultPermanent # CS.lkas_hud['LKAS_PROBLEM']
-      lkas_hud_values['DASHED_LANES'] = 1  # show gray lanes when disengaged
+      if CP.carFingerprint in HONDA_BOSCH_RADARLESS:
+        lkas_hud_values['DASHED_LANES'] = 1  # show gray lanes when disengaged
+      else:
+        # CAN FD: dashed lanes are the MADS armed indication (MadsCarController sets dashed_lanes to
+        # mads.enabled and not latActive, which is not standstill-gated - so parked/standstill LKAS
+        # button presses produce cluster feedback; latActive alone stays 0 below 0.3 m/s and armed
+        # toggles would render nothing). ORed with lat_active while steering so the engaged payload
+        # keeps SOLID and DASHED set together (0x44), byte-matching the stock camera's lanes-on state.
+        lkas_hud_values['DASHED_LANES'] = dashed_lanes or lat_active
 
     if CP.carFingerprint in HONDA_BOSCH_CANFD:
       # Don't let steer saturation flicker SOLID_LANES: every payload change must coincide with an


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

This PR previously contained the `SOLID_LANES`-override-in-place structural fix; that fix has since landed directly on `sp-honda-dev-202608` (`9854ca299`, same content, applied outside this PR), so this branch has been rebased onto the current tip and now carries only the next fix from the updated [`openpilot` PR #149](https://github.com/mvl-boston/openpilot/pull/149).

## Problem

Two stacked regressions from the 202608 CAN-FD merge broke the MADS LKAS cluster indication on Honda CAN FD (Accord 11G tester reports; routes `6504a94602f1de53|00000054--e187ba87c4` and `|00000056--61de328259`):

1. `SOLID_LANES` keyed on `hud_control.lanesVisible` (== `CC.enabled`) instead of `latActive` — **already fixed** (`9854ca299` / `3e710d5b8`, currently on this branch's base).
2. **`DASHED_LANES` overridden to a constant `1`** on CAN FD, which clobbered sunnypilot's MADS armed-state feedback channel (`MadsCarController.dashed_lanes = mads.enabled and not latActive`). Since `latActive` is standstill-gated in controlsd (`abs(vEgo) <= 0.3`), pressing the LKAS button while parked toggled MADS with **zero cluster reaction** — route 56 is an all-standstill drive with 15+ LKAS presses, MADS toggling in `selfdriveStateSP`, but the `LKAS_HUD` payload never changing on armed toggles. The stock camera can't provide the armed indication either, since its LKAS is unavailable while the radar is silenced.

## Fix (this PR)

- `hondacan.create_lkas_hud`: on CAN FD, `DASHED_LANES = dashed_lanes or lat_active` — armed toggles now render at standstill, and the engaged payload keeps `SOLID` and `DASHED` set together (`0x44`), byte-matching the stock camera's lanes-on state. Radarless keeps its constant gray lanes (unaffected, separate branch).
- `carcontroller`: `self.dashed_lanes` (MADS armed, from `MadsCarController`) added to the `LKAS_STATE_CHANGE` pulse key alongside `latActive`, so every `DASHED_LANES` payload change still coincides with a state-change pulse.

This commit is **sunnypilot-only** — it uses the `MadsCarController.dashed_lanes` signal, which doesn't exist on the comma-based `0111-op-honda-dev` lineage. Do not cherry-pick it there.

## Verification

- Offline CarController harness (ACCORD_11G, MADS available): disarmed idle `SOLID=0 DASHED=0`; MADS armed at standstill `SOLID=0 DASHED=1` (parked LKAS press now reacts); MADS steering and fully engaged both `SOLID=1 DASHED=1` (`414400481800..`, factory lanes-on payload); disarm returns to `0/0`.
- `LKAS_STATE_CHANGE` pulse: `dashed_lanes` added to the pulse key; pulse fires on every arm/disarm payload change and clears after exactly 3.0s (never latches high, which would suppress lane rendering).
- Brake-press regression case from route 54 still fixed: MADS-only state renders `SOLID=1`.
- `opendbc/safety/tests/test_honda.py`: 951 tests pass, 69 skipped.
- `opendbc/car/honda/tests/test_honda.py`: pass.
- `ruff check` on changed files: clean.
- Not yet verified on-car.

## Routes

- `6504a94602f1de53|00000054--e187ba87c4` (segments 17, 27, 28) — brake-press regression
- `6504a94602f1de53|00000056--61de328259` — parked demo, standstill-arming regression

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92aa1be4-85ad-42ca-b1f4-30e84cd6a105?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92aa1be4-85ad-42ca-b1f4-30e84cd6a105&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

