### PR TITLE
Honda dash lanes: slew-rate limit displayed LANE_PATH offsets (sp)

### DIFF
--- a/opendbc/car/honda/lane_path.py
+++ b/opendbc/car/honda/lane_path.py
@@ -19,6 +19,15 @@ MUX_CYCLE = tuple(idx + bank * 16 for bank in range(4) for idx in range(1, NUM_I
 OFFSET_UNAVAILABLE = 2047  # camera's "no point" sentinel (12-bit signed max)
 OFFSET_VALID_MAX = 2046    # clamp real offsets below the sentinel
 
+# Slew-rate limit on the displayed path: the model's lane prediction can jump frame-to-frame when it
+# is uncertain, and the dash lanes jump with it. Cap how far each displayed offset may move per
+# update so a full swing from center (0) to full scale (OFFSET_VALID_MAX, max turn) takes
+# SLEW_FULL_SCALE_SECONDS. The carcontroller refits the path at 50 Hz on both the radarless
+# (frame % 2 == 0) and CAN FD (radar 50 Hz tick) paths.
+SLEW_UPDATE_RATE_HZ = 50.0
+SLEW_FULL_SCALE_SECONDS = 2.0  # center -> max turn takes this long
+SLEW_MAX_STEP = OFFSET_VALID_MAX / (SLEW_FULL_SCALE_SECONDS * SLEW_UPDATE_RATE_HZ)  # raw units per update
+
 D_NEAR = 2.0
 D_MAX = 100.0
 LOOKAHEAD = np.linspace(D_NEAR, D_MAX, NUM_PTS)               # look-ahead distance of each offset
@@ -179,6 +188,22 @@ class LanePathFitter:
   def __init__(self):
     self._left_on = False
     self._right_on = False
+    self._displayed = None  # slewed float copy of the 40 raw offsets currently on the dash
+
+  def _slew(self, offsets):
+    """Rate-limit the displayed offsets toward the new fit (SLEW_MAX_STEP per update) so the dash
+    lane can't jump when the model's prediction jumps. An all-sentinel fit (path short of D_MAX)
+    draws nothing, so pass it through and reset; likewise start at the fit when nothing was drawn
+    (no visible jump either way)."""
+    if offsets[0] == OFFSET_UNAVAILABLE:
+      self._displayed = None
+      return offsets
+    target = np.asarray(offsets, dtype=float)
+    if self._displayed is None:
+      self._displayed = target
+    else:
+      self._displayed = self._displayed + np.clip(target - self._displayed, -SLEW_MAX_STEP, SLEW_MAX_STEP)
+    return [int(v) for v in np.round(self._displayed)]
 
   def update(self, model, v_ego, lead_d) -> DashLane:
     """`model` = modelV2 (None when invalid); `v_ego` m/s; `lead_d` lead distance m (0 = none). Returns a DashLane.
@@ -192,10 +217,12 @@ class LanePathFitter:
     if model is not None:
       x, y, left_on, right_on = select_lane_render(model, self._left_on, self._right_on)
     if x is None:
+      self._displayed = None
       return blank
     self._left_on, self._right_on = left_on, right_on
 
     reach = float(np.clip(max(v_ego / DASH_PATH_FULL_LEN_SPEED, lead_d / DASH_PATH_LEAD_FULL_DIST, DASH_PATH_MIN_REACH), 0.0, 1.0))
     if round(reach * LANE_LENGTH_MAX_VALUE) <= 0:
+      self._displayed = None
       return blank
-    return DashLane(encode_lane_path(x, y), reach, left_on, right_on, v_ego=v_ego)
+    return DashLane(self._slew(encode_lane_path(x, y)), reach, left_on, right_on, v_ego=v_ego)

--- a/opendbc/car/honda/tests/test_lane_path.py
+++ b/opendbc/car/honda/tests/test_lane_path.py
@@ -1,0 +1,90 @@
+import math
+import unittest
+from types import SimpleNamespace
+
+import numpy as np
+
+from opendbc.car.honda import lane_path
+
+
+def model_at(center_y):
+  """Fake modelV2 with both ego lane lines fully confident and the lane center at center_y (m, +left)."""
+  x = list(np.linspace(0.0, 110.0, 23))
+
+  def line(y):
+    return SimpleNamespace(x=x, y=[y] * len(x))
+  return SimpleNamespace(laneLines=[line(center_y + 3.3), line(center_y + 1.65), line(center_y - 1.65), line(center_y - 3.3)],
+                         laneLineProbs=[0.0, 1.0, 1.0, 0.0])
+
+
+V_EGO = 30.0
+
+
+class TestLanePathSlew(unittest.TestCase):
+  def test_first_fit_shown_unslewed(self):
+    # nothing on the dash yet: start at the fit, no ramp-in from center
+    fitter = lane_path.LanePathFitter()
+    dl = fitter.update(model_at(-2.0), V_EGO, 0.0)
+    assert dl.offsets == lane_path.encode_lane_path(*_lane_xy(-2.0))
+
+  def test_step_is_rate_limited(self):
+    fitter = lane_path.LanePathFitter()
+    prev = fitter.update(model_at(0.0), V_EGO, 0.0).offsets
+    assert all(o == 0 for o in prev)
+
+    target = lane_path.encode_lane_path(*_lane_xy(-2.0))
+    max_step = math.ceil(lane_path.SLEW_MAX_STEP)
+    for _ in range(10):
+      cur = fitter.update(model_at(-2.0), V_EGO, 0.0).offsets
+      for p, c, t in zip(prev, cur, target, strict=True):
+        assert abs(c - p) <= max_step
+        assert abs(t - c) <= abs(t - p)  # monotonic approach
+      prev = cur
+    assert prev == target  # |target| ~ 60 raw: converged well within 10 updates
+
+  def test_full_scale_takes_two_seconds(self):
+    # center -> full-scale (max turn) must take SLEW_FULL_SCALE_SECONDS at the 50 Hz update rate
+    fitter = lane_path.LanePathFitter()
+    fitter.update(model_at(0.0), V_EGO, 0.0)
+    target = lane_path.encode_lane_path(*_lane_xy(-100.0))  # saturates every offset at OFFSET_VALID_MAX
+    assert all(t == lane_path.OFFSET_VALID_MAX for t in target)
+
+    n_updates = round(lane_path.SLEW_FULL_SCALE_SECONDS * lane_path.SLEW_UPDATE_RATE_HZ)
+    for i in range(n_updates):
+      dl = fitter.update(model_at(-100.0), V_EGO, 0.0)
+      if i < n_updates - 1:
+        assert dl.offsets != target
+    assert dl.offsets == target
+
+  def test_blank_resets_slew(self):
+    # once the lane blanks off the dash, the next fit is shown directly (no slew across the gap)
+    fitter = lane_path.LanePathFitter()
+    fitter.update(model_at(0.0), V_EGO, 0.0)
+    dl = fitter.update(None, V_EGO, 0.0)
+    assert dl.offsets == [lane_path.OFFSET_UNAVAILABLE] * lane_path.NUM_PTS
+    dl = fitter.update(model_at(-2.0), V_EGO, 0.0)
+    assert dl.offsets == lane_path.encode_lane_path(*_lane_xy(-2.0))
+
+  def test_short_path_passthrough_and_reset(self):
+    # a fit that doesn't reach D_MAX encodes all-sentinel: pass it through and reset the slew state
+    fitter = lane_path.LanePathFitter()
+    fitter.update(model_at(0.0), V_EGO, 0.0)
+
+    short = model_at(-2.0)
+    for ll in short.laneLines:
+      ll.x = ll.x[:10]  # max ~50 m < D_MAX
+      ll.y = ll.y[:10]
+    dl = fitter.update(short, V_EGO, 0.0)
+    assert dl.offsets == [lane_path.OFFSET_UNAVAILABLE] * lane_path.NUM_PTS
+
+    dl = fitter.update(model_at(-2.0), V_EGO, 0.0)
+    assert dl.offsets == lane_path.encode_lane_path(*_lane_xy(-2.0))
+
+
+def _lane_xy(center_y):
+  m = model_at(center_y)
+  return m.laneLines[1].x, [(a + b) / 2.0 for a, b in zip(m.laneLines[1].y, m.laneLines[2].y, strict=True)]
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Test drivers report the openpilot-authored dash lane lines are too jumpy. The display followed the model's lane prediction exactly, so when the model is uncertain and its prediction jumps frame-to-frame, the rendered lanes jump with it.

## Change

Identical commit to https://github.com/mvl-boston/opendbc/pull/645 (base `0111-op-honda-dev`), cherry-picked onto `sp-honda-dev-202608`. It applies cleanly because `lane_path.py` is byte-identical on both branches and no `carcontroller.py` changes are needed.

Introduce a maximum per-update change on the displayed lane path in `LanePathFitter` (`opendbc/car/honda/lane_path.py`), covering both the radarless and CAN FD paths since both flow through `LanePathFitter.update()` at 50 Hz:

- Each of the 40 displayed raw offsets may move at most `SLEW_MAX_STEP = OFFSET_VALID_MAX / (2.0 s * 50 Hz)` (~20.5 raw units) per update, so a full swing from center (0) to full scale (`OFFSET_VALID_MAX` = 2046, max turn) takes 2 seconds. `SLEW_FULL_SCALE_SECONDS` is the tuning knob if 2 s turns out too slow/fast on the road.
- The slew state is held as floats so sub-unit steps accumulate correctly; offsets are rounded only when handed to the packer.
- When nothing is currently drawn (first fit after startup, after a blank/low-confidence period, or after an all-sentinel short path), the new fit is shown directly rather than ramped in — there is no visible jump to smooth, and ramping in would draw a wrong lane during the transition.
- CAN FD's terminated-prefix reshaping (`canfd_lane_offsets`) and the radarless `LKAS_HUD_2` path both consume the already-slewed `DashLane.offsets`, so no `carcontroller.py` changes are needed.

## Tests

New `opendbc/car/honda/tests/test_lane_path.py` (plain `unittest`, run with `python3 opendbc/car/honda/tests/test_lane_path.py`):

- first fit is shown unslewed
- a step change is rate-limited and approaches the target monotonically
- center → full-scale takes exactly 2 s of 50 Hz updates
- blanking (model invalid / lines not confident) resets the slew state
- an all-sentinel short path passes through untouched and resets

All 5 pass on this branch; `ruff check` clean.

Validation
* Dongle ID: (not yet driven on-car)
* Route: (not yet driven on-car)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69a6ca3f-f9a0-4fe0-bea3-49bf923f627f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69a6ca3f-f9a0-4fe0-bea3-49bf923f627f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

