### PR TITLE
opendbc: honda: fix typo for Honda Fit 4G

### DIFF
--- a/opendbc/car/honda/interface.py
+++ b/opendbc/car/honda/interface.py
@@ -256,7 +256,7 @@ class CarInterface(CarInterfaceBase):
       ):
       pass
 
-    elif candidate in CAR.HONDA_FIT_4G:
+    elif candidate == CAR.HONDA_FIT_4G:
       ret.steerActuatorDelay = 0.15
       ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 4096], [0, 4096]]
       CarInterfaceBase.configure_torque_tune(candidate, ret.lateralTuning)


### PR DESCRIPTION
Fix a typo in the Honda Fit 4G candidate check.

CAR.HONDA_FIT_4G is a single car platform rather than a collection, so use equality (==) instead of the membership operator (in).